### PR TITLE
Feat/reworking food intake

### DIFF
--- a/Feature.md
+++ b/Feature.md
@@ -13,3 +13,8 @@
 - Barcode “not found” fallback — open an add new food form which will be manually added. The user will be able to also add the macros via a nutritional bar scan from a picture.
 - Trend windows — 7 / 14 / 30-day chart filters and simple stats (rate of change, consistency).
 - Weigh-in streaks / reminders — You already have notifications; surfacing adherence in UI helps motivation without new data.
+
+## Data cleaning in opennutrition
+
+- create a script that will clean and remove any unwanted products. I only want to retain the whole none branded food from that database.
+- remove any duplicate.

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -16,10 +16,6 @@ android {
         isCoreLibraryDesugaringEnabled = true
     }
 
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17.toString()
-    }
-
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId = "com.caltrack.caltrack"
@@ -37,6 +33,12 @@ android {
             // Signing with the debug keys for now, so `flutter run --release` works.
             signingConfig = signingConfigs.getByName("debug")
         }
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     }
 }
 

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -5,6 +5,34 @@ allprojects {
     }
 }
 
+// Ensure all Android subprojects compile with modern Java/Kotlin targets.
+// Some dependencies still default to Java 8 (-source/-target 8), which triggers
+// noisy warnings on newer toolchains.
+subprojects {
+    plugins.withId("com.android.application") {
+        extensions.configure<com.android.build.gradle.BaseExtension>("android") {
+            compileOptions {
+                sourceCompatibility = JavaVersion.VERSION_17
+                targetCompatibility = JavaVersion.VERSION_17
+            }
+        }
+    }
+    plugins.withId("com.android.library") {
+        extensions.configure<com.android.build.gradle.BaseExtension>("android") {
+            compileOptions {
+                sourceCompatibility = JavaVersion.VERSION_17
+                targetCompatibility = JavaVersion.VERSION_17
+            }
+        }
+    }
+
+    tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
+        compilerOptions {
+            jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
+        }
+    }
+}
+
 val newBuildDir: Directory =
     rootProject.layout.buildDirectory
         .dir("../../build")

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -1,6 +1,8 @@
 import 'package:caltrack/app/profile_controller.dart';
+import 'package:caltrack/features/food/add_custom_food_screen.dart';
 import 'package:caltrack/features/food/barcode_scan_screen.dart';
 import 'package:caltrack/features/food/log_food_screen.dart';
+import 'package:caltrack/features/food/nutrition_label_scan_screen.dart';
 import 'package:caltrack/features/onboarding/onboarding_screen.dart';
 import 'package:caltrack/features/settings/settings_screen.dart';
 import 'package:caltrack/features/shell/root_shell.dart';
@@ -51,6 +53,18 @@ GoRouter createRouter(ProfileController profileController) {
       GoRoute(
         path: '/scan-barcode',
         builder: (context, state) => const BarcodeScanScreen(),
+      ),
+      GoRoute(
+        path: '/add-custom-food',
+        builder: (context, state) {
+          final extra = state.extra;
+          final barcode = extra is Map ? extra['barcode'] as String? : null;
+          return AddCustomFoodScreen(initialBarcode: barcode);
+        },
+      ),
+      GoRoute(
+        path: '/scan-nutrition-label',
+        builder: (context, state) => const NutritionLabelScanScreen(),
       ),
     ],
   );

--- a/lib/core/nutrition_label_parser.dart
+++ b/lib/core/nutrition_label_parser.dart
@@ -1,0 +1,325 @@
+import 'dart:ui';
+
+import 'package:caltrack/data/app_database.dart';
+import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+
+enum NutritionField {
+  servingSize,
+  calories,
+  totalFat,
+  totalCarbs,
+  sugar,
+  fiber,
+  protein,
+}
+
+class ExtractedField<T> {
+  const ExtractedField({required this.value, required this.box});
+
+  final T value;
+  final Rect box;
+}
+
+class NutritionParseResult {
+  const NutritionParseResult({required this.draft, required this.fields});
+
+  final ({
+    double? servingSize,
+    ServingUnit? servingUnit,
+    double? calories,
+    double? fatG,
+    double? carbsG,
+    double? sugarG,
+    double? fiberG,
+    double? proteinG,
+  })
+  draft;
+
+  final Map<NutritionField, ExtractedField<double>> fields;
+}
+
+class OcrLine {
+  const OcrLine({required this.text, required this.box});
+
+  final String text;
+  final Rect box;
+}
+
+// ---------------------------------------------------------------------------
+// Regex helpers
+// ---------------------------------------------------------------------------
+
+/// Matches a number followed by a gram unit, e.g. "30 g", "30g", "3,5 gr".
+/// Word-boundary anchored so "sugar", "grams of fat", etc. don't match.
+final RegExp _gramQuantity = RegExp(
+  r'(\d+(?:[.,]\d+)?)\s*(?:g|gr|gramme[s]?|grams?)\b',
+  caseSensitive: false,
+);
+
+/// Matches a number followed by a millilitre unit.
+final RegExp _mlQuantity = RegExp(
+  r'(\d+(?:[.,]\d+)?)\s*(?:ml|millilitre[s]?|milliliter[s]?)\b',
+  caseSensitive: false,
+);
+
+/// Bare number anywhere in the string.
+final RegExp _bareNumber = RegExp(r'(-?\d+(?:[.,]\d+)?)');
+
+double? _toDouble(String? raw) {
+  if (raw == null) return null;
+  return double.tryParse(raw.replaceAll(',', '.'));
+}
+
+double? _firstNumber(String s) => _toDouble(_bareNumber.firstMatch(s)?.group(1));
+
+/// First explicit "<n> g" quantity in the line (ignores other numbers).
+double? _firstGramQuantity(String s) =>
+    _toDouble(_gramQuantity.firstMatch(s)?.group(1));
+
+/// First explicit "<n> ml" quantity in the line.
+double? _firstMlQuantity(String s) =>
+    _toDouble(_mlQuantity.firstMatch(s)?.group(1));
+
+/// A serving-size measurement preferring the LAST occurrence on the line so
+/// labels like "Per 1 cup (30 g)" pick the 30 g, not the 1.
+({double value, ServingUnit unit})? _extractServingMeasurement(String s) {
+  final mls = _mlQuantity.allMatches(s).toList();
+  if (mls.isNotEmpty) {
+    final v = _toDouble(mls.last.group(1));
+    if (v != null) return (value: v, unit: ServingUnit.ml);
+  }
+  final gs = _gramQuantity.allMatches(s).toList();
+  if (gs.isNotEmpty) {
+    final v = _toDouble(gs.last.group(1));
+    if (v != null) return (value: v, unit: ServingUnit.g);
+  }
+  return null;
+}
+
+bool _matchesAny(String text, List<RegExp> patterns) {
+  for (final p in patterns) {
+    if (p.hasMatch(text)) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Bilingual (EN/FR) keyword vocabulary
+// ---------------------------------------------------------------------------
+
+/// Words that introduce a serving-size declaration on a line. Permissive on
+/// purpose; we still require a g/mL measurement to actually accept it, which
+/// filters out incidental matches like "% Daily Value per serving".
+final List<RegExp> _servingHeaderPatterns = [
+  RegExp(r'\bserving size\b', caseSensitive: false),
+  RegExp(r'\bservings?\b', caseSensitive: false),
+  RegExp(r'\bportion\b', caseSensitive: false),
+  RegExp(r'\bpar portion\b', caseSensitive: false),
+  RegExp(r'\bvaleur nutritive\b', caseSensitive: false),
+  RegExp(r'^\s*per\b', caseSensitive: false),
+  RegExp(r'\bper\s+\d', caseSensitive: false),
+  RegExp(r'\bper\s+[a-zàâçéèêëîïôûùüÿñæœ]+', caseSensitive: false),
+  RegExp(r'^\s*pour\b', caseSensitive: false),
+  RegExp(r'\bpour\s+\d', caseSensitive: false),
+  RegExp(r'\bpour\s+[a-zàâçéèêëîïôûùüÿñæœ]+', caseSensitive: false),
+];
+
+final List<RegExp> _caloriePatterns = [
+  RegExp(r'\bcalories\b', caseSensitive: false),
+  RegExp(r'\bcalorie\b', caseSensitive: false),
+  // French labels sometimes use "Énergie" with kcal.
+  RegExp(r'\b[ée]nergie\b', caseSensitive: false),
+];
+
+final List<RegExp> _fatPatterns = [
+  RegExp(r'\btotal fat\b', caseSensitive: false),
+  RegExp(r'\bfat\b', caseSensitive: false),
+  RegExp(r'\blipides?\b', caseSensitive: false),
+  RegExp(r'\bmati[èe]res?\s+grasses?\b', caseSensitive: false),
+];
+
+final List<RegExp> _carbsPatterns = [
+  RegExp(r'\btotal carbohydrate[s]?\b', caseSensitive: false),
+  RegExp(r'\bcarbohydrate[s]?\b', caseSensitive: false),
+  RegExp(r'\btotal carb[s]?\b', caseSensitive: false),
+  RegExp(r'\bcarb[s]?\b', caseSensitive: false),
+  RegExp(r'\bglucides?\b', caseSensitive: false),
+];
+
+final List<RegExp> _fiberPatterns = [
+  RegExp(r'\bdietary fib(?:re|er)\b', caseSensitive: false),
+  RegExp(r'\bfib(?:re|er)s?\b', caseSensitive: false),
+  RegExp(r'\bfibres?\s+alimentaires?\b', caseSensitive: false),
+];
+
+final List<RegExp> _sugarPatterns = [
+  RegExp(r'\btotal sugars?\b', caseSensitive: false),
+  RegExp(r'\bincludes?\b.*\bsugars?\b', caseSensitive: false),
+  RegExp(r'\bsugars?\b', caseSensitive: false),
+  RegExp(r'\bsucres?\b', caseSensitive: false),
+];
+
+final List<RegExp> _proteinPatterns = [
+  RegExp(r'\bproteins?\b', caseSensitive: false),
+  RegExp(r'\bprot[ée]ines?\b', caseSensitive: false),
+];
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+NutritionParseResult parseNutritionLabel(RecognizedText text) {
+  final lines = <OcrLine>[];
+  for (final b in text.blocks) {
+    for (final l in b.lines) {
+      lines.add(OcrLine(text: l.text, box: l.boundingBox));
+    }
+  }
+  return parseNutritionLabelFromLines(lines);
+}
+
+NutritionParseResult parseNutritionLabelFromLines(Iterable<OcrLine> lines) {
+  final list = lines.toList(growable: false);
+
+  ExtractedField<double>? calories;
+  ExtractedField<double>? fat;
+  ExtractedField<double>? carbs;
+  ExtractedField<double>? sugar;
+  ExtractedField<double>? fiber;
+  ExtractedField<double>? protein;
+
+  double? servingSize;
+  ServingUnit? servingUnit;
+  Rect? servingBox;
+
+  for (var i = 0; i < list.length; i++) {
+    final line = list[i];
+    final raw = line.text;
+    final box = line.box;
+
+    // Serving size: keyword + (g | mL) measurement on this or one of the
+    // next two lines (covers vertical "Serving size\n1 cup (30 g)" layouts).
+    if (servingSize == null && _matchesAny(raw, _servingHeaderPatterns)) {
+      var m = _extractServingMeasurement(raw);
+      if (m == null) {
+        for (var j = 1; j <= 2 && (i + j) < list.length; j++) {
+          m = _extractServingMeasurement(list[i + j].text);
+          if (m != null) break;
+        }
+      }
+      if (m != null) {
+        servingSize = m.value;
+        servingUnit = m.unit;
+        servingBox = box;
+        continue;
+      }
+    }
+
+    // Calories: number is dimensionless; allow the value to live on the
+    // next line for vertical layouts.
+    if (calories == null && _matchesAny(raw, _caloriePatterns)) {
+      var n = _firstNumber(raw);
+      if (n == null && i + 1 < list.length) {
+        n = _firstNumber(list[i + 1].text);
+      }
+      if (n != null) {
+        calories = ExtractedField(value: n, box: box);
+        continue;
+      }
+    }
+
+    // Macros: prefer the gram-anchored number (skips "% Daily Value" digits
+    // and other companions); fall back to the first bare number if needed.
+    if (fat == null && _matchesAny(raw, _fatPatterns)) {
+      final n = _firstGramQuantity(raw) ?? _firstNumber(raw);
+      if (n != null) {
+        fat = ExtractedField(value: n, box: box);
+        continue;
+      }
+    }
+
+    if (carbs == null && _matchesAny(raw, _carbsPatterns)) {
+      final n = _firstGramQuantity(raw) ?? _firstNumber(raw);
+      if (n != null) {
+        carbs = ExtractedField(value: n, box: box);
+        continue;
+      }
+    }
+
+    // Fiber checked before sugar so combined lines like "Fibres / Sucres"
+    // (rare) don't get over-eagerly assigned to sugar.
+    if (fiber == null && _matchesAny(raw, _fiberPatterns)) {
+      final n = _firstGramQuantity(raw) ?? _firstNumber(raw);
+      if (n != null) {
+        fiber = ExtractedField(value: n, box: box);
+        continue;
+      }
+    }
+
+    if (sugar == null && _matchesAny(raw, _sugarPatterns)) {
+      final n = _firstGramQuantity(raw) ?? _firstNumber(raw);
+      if (n != null) {
+        sugar = ExtractedField(value: n, box: box);
+        continue;
+      }
+    }
+
+    if (protein == null && _matchesAny(raw, _proteinPatterns)) {
+      final n = _firstGramQuantity(raw) ?? _firstNumber(raw);
+      if (n != null) {
+        protein = ExtractedField(value: n, box: box);
+        continue;
+      }
+    }
+  }
+
+  // Last-resort: if no serving header matched but the OCR contains a stand-
+  // alone "<n> g" or "<n> mL" line near the top, use it. Helps with very
+  // tightly cropped labels where the header is cut off.
+  if (servingSize == null) {
+    for (var i = 0; i < list.length && i < 6; i++) {
+      final ml = _firstMlQuantity(list[i].text);
+      if (ml != null) {
+        servingSize = ml;
+        servingUnit = ServingUnit.ml;
+        servingBox = list[i].box;
+        break;
+      }
+      final g = _firstGramQuantity(list[i].text);
+      if (g != null) {
+        servingSize = g;
+        servingUnit = ServingUnit.g;
+        servingBox = list[i].box;
+        break;
+      }
+    }
+  }
+
+  final fields = <NutritionField, ExtractedField<double>>{};
+  if (calories != null) fields[NutritionField.calories] = calories;
+  if (fat != null) fields[NutritionField.totalFat] = fat;
+  if (carbs != null) fields[NutritionField.totalCarbs] = carbs;
+  if (sugar != null) fields[NutritionField.sugar] = sugar;
+  if (fiber != null) fields[NutritionField.fiber] = fiber;
+  if (protein != null) fields[NutritionField.protein] = protein;
+  if (servingSize != null && servingBox != null) {
+    fields[NutritionField.servingSize] = ExtractedField(
+      value: servingSize,
+      box: servingBox,
+    );
+  }
+
+  return NutritionParseResult(
+    draft: (
+      servingSize: servingSize,
+      servingUnit: servingUnit,
+      calories: calories?.value,
+      fatG: fat?.value,
+      carbsG: carbs?.value,
+      sugarG: sugar?.value,
+      fiberG: fiber?.value,
+      proteinG: protein?.value,
+    ),
+    fields: fields,
+  );
+}

--- a/lib/core/nutrition_label_parser.dart
+++ b/lib/core/nutrition_label_parser.dart
@@ -72,11 +72,11 @@ double? _toDouble(String? raw) {
 
 double? _firstNumber(String s) => _toDouble(_bareNumber.firstMatch(s)?.group(1));
 
-/// First explicit "<n> g" quantity in the line (ignores other numbers).
+/// First explicit `<n> g` quantity in the line (ignores other numbers).
 double? _firstGramQuantity(String s) =>
     _toDouble(_gramQuantity.firstMatch(s)?.group(1));
 
-/// First explicit "<n> ml" quantity in the line.
+/// First explicit `<n> ml` quantity in the line.
 double? _firstMlQuantity(String s) =>
     _toDouble(_mlQuantity.firstMatch(s)?.group(1));
 

--- a/lib/data/app_database.dart
+++ b/lib/data/app_database.dart
@@ -45,28 +45,61 @@ class WeightEntries extends Table {
   TextColumn get note => text().nullable()();
 }
 
+enum ServingUnit { g, ml }
+
+/// User-created foods stored locally for fast re-use and barcode lookup.
+class CustomFoods extends Table {
+  IntColumn get id => integer().autoIncrement()();
+
+  /// Required display name, e.g. "Greek yogurt".
+  TextColumn get name => text()();
+
+  /// Optional, e.g. "Chobani".
+  TextColumn get brand => text().nullable()();
+
+  /// Optional, normalized digits (EAN-13 if present).
+  TextColumn get barcode => text().nullable()();
+
+  /// Serving size amount (in [servingUnit]).
+  RealColumn get servingSize => real()();
+
+  /// 'g' | 'ml'
+  TextColumn get servingUnit => text()();
+
+  /// Nutrition per serving.
+  RealColumn get calories => real()();
+  RealColumn get fatG => real()();
+  RealColumn get carbsG => real()();
+  RealColumn get sugarG => real()();
+  RealColumn get fiberG => real()();
+  RealColumn get proteinG => real()();
+}
+
 /// Logged food with snapshot macros for the chosen portion (not per-100g).
 class FoodLogEntries extends Table {
   IntColumn get id => integer().autoIncrement()();
   DateTimeColumn get loggedAt => dateTime()();
   TextColumn get source => text()(); // opennutrition | custom
   TextColumn get catalogFoodId => text().nullable()();
+  IntColumn get customFoodId => integer().nullable()();
   TextColumn get displayName => text()();
   RealColumn get grams => real()();
   RealColumn get kcal => real()();
   RealColumn get proteinG => real()();
   RealColumn get carbsG => real()();
+  RealColumn get sugarG => real().withDefault(const Constant(0))();
+  RealColumn get fiberG => real().withDefault(const Constant(0))();
   RealColumn get fatG => real()();
 }
 
-@DriftDatabase(tables: [Profiles, Goals, WeightEntries, FoodLogEntries])
+@DriftDatabase(tables: [Profiles, Goals, WeightEntries, CustomFoods, FoodLogEntries])
 class AppDatabase extends _$AppDatabase {
   AppDatabase() : super(_openConnection());
 
   AppDatabase.forTesting(super.e);
 
   @override
-  int get schemaVersion => 2;
+  int get schemaVersion => 3;
 
   @override
   MigrationStrategy get migration => MigrationStrategy(
@@ -76,6 +109,12 @@ class AppDatabase extends _$AppDatabase {
         onUpgrade: (Migrator m, int from, int to) async {
           if (from < 2) {
             await m.createTable(foodLogEntries);
+          }
+          if (from < 3) {
+            await m.createTable(customFoods);
+            await m.addColumn(foodLogEntries, foodLogEntries.customFoodId);
+            await m.addColumn(foodLogEntries, foodLogEntries.sugarG);
+            await m.addColumn(foodLogEntries, foodLogEntries.fiberG);
           }
         },
       );

--- a/lib/data/app_database.g.dart
+++ b/lib/data/app_database.g.dart
@@ -1451,6 +1451,712 @@ class WeightEntriesCompanion extends UpdateCompanion<WeightEntry> {
   }
 }
 
+class $CustomFoodsTable extends CustomFoods
+    with TableInfo<$CustomFoodsTable, CustomFood> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $CustomFoodsTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<int> id = GeneratedColumn<int>(
+    'id',
+    aliasedName,
+    false,
+    hasAutoIncrement: true,
+    type: DriftSqlType.int,
+    requiredDuringInsert: false,
+    defaultConstraints: GeneratedColumn.constraintIsAlways(
+      'PRIMARY KEY AUTOINCREMENT',
+    ),
+  );
+  static const VerificationMeta _nameMeta = const VerificationMeta('name');
+  @override
+  late final GeneratedColumn<String> name = GeneratedColumn<String>(
+    'name',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _brandMeta = const VerificationMeta('brand');
+  @override
+  late final GeneratedColumn<String> brand = GeneratedColumn<String>(
+    'brand',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _barcodeMeta = const VerificationMeta(
+    'barcode',
+  );
+  @override
+  late final GeneratedColumn<String> barcode = GeneratedColumn<String>(
+    'barcode',
+    aliasedName,
+    true,
+    type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _servingSizeMeta = const VerificationMeta(
+    'servingSize',
+  );
+  @override
+  late final GeneratedColumn<double> servingSize = GeneratedColumn<double>(
+    'serving_size',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _servingUnitMeta = const VerificationMeta(
+    'servingUnit',
+  );
+  @override
+  late final GeneratedColumn<String> servingUnit = GeneratedColumn<String>(
+    'serving_unit',
+    aliasedName,
+    false,
+    type: DriftSqlType.string,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _caloriesMeta = const VerificationMeta(
+    'calories',
+  );
+  @override
+  late final GeneratedColumn<double> calories = GeneratedColumn<double>(
+    'calories',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _fatGMeta = const VerificationMeta('fatG');
+  @override
+  late final GeneratedColumn<double> fatG = GeneratedColumn<double>(
+    'fat_g',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _carbsGMeta = const VerificationMeta('carbsG');
+  @override
+  late final GeneratedColumn<double> carbsG = GeneratedColumn<double>(
+    'carbs_g',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _sugarGMeta = const VerificationMeta('sugarG');
+  @override
+  late final GeneratedColumn<double> sugarG = GeneratedColumn<double>(
+    'sugar_g',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _fiberGMeta = const VerificationMeta('fiberG');
+  @override
+  late final GeneratedColumn<double> fiberG = GeneratedColumn<double>(
+    'fiber_g',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: true,
+  );
+  static const VerificationMeta _proteinGMeta = const VerificationMeta(
+    'proteinG',
+  );
+  @override
+  late final GeneratedColumn<double> proteinG = GeneratedColumn<double>(
+    'protein_g',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: true,
+  );
+  @override
+  List<GeneratedColumn> get $columns => [
+    id,
+    name,
+    brand,
+    barcode,
+    servingSize,
+    servingUnit,
+    calories,
+    fatG,
+    carbsG,
+    sugarG,
+    fiberG,
+    proteinG,
+  ];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'custom_foods';
+  @override
+  VerificationContext validateIntegrity(
+    Insertable<CustomFood> instance, {
+    bool isInserting = false,
+  }) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    }
+    if (data.containsKey('name')) {
+      context.handle(
+        _nameMeta,
+        name.isAcceptableOrUnknown(data['name']!, _nameMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_nameMeta);
+    }
+    if (data.containsKey('brand')) {
+      context.handle(
+        _brandMeta,
+        brand.isAcceptableOrUnknown(data['brand']!, _brandMeta),
+      );
+    }
+    if (data.containsKey('barcode')) {
+      context.handle(
+        _barcodeMeta,
+        barcode.isAcceptableOrUnknown(data['barcode']!, _barcodeMeta),
+      );
+    }
+    if (data.containsKey('serving_size')) {
+      context.handle(
+        _servingSizeMeta,
+        servingSize.isAcceptableOrUnknown(
+          data['serving_size']!,
+          _servingSizeMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_servingSizeMeta);
+    }
+    if (data.containsKey('serving_unit')) {
+      context.handle(
+        _servingUnitMeta,
+        servingUnit.isAcceptableOrUnknown(
+          data['serving_unit']!,
+          _servingUnitMeta,
+        ),
+      );
+    } else if (isInserting) {
+      context.missing(_servingUnitMeta);
+    }
+    if (data.containsKey('calories')) {
+      context.handle(
+        _caloriesMeta,
+        calories.isAcceptableOrUnknown(data['calories']!, _caloriesMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_caloriesMeta);
+    }
+    if (data.containsKey('fat_g')) {
+      context.handle(
+        _fatGMeta,
+        fatG.isAcceptableOrUnknown(data['fat_g']!, _fatGMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_fatGMeta);
+    }
+    if (data.containsKey('carbs_g')) {
+      context.handle(
+        _carbsGMeta,
+        carbsG.isAcceptableOrUnknown(data['carbs_g']!, _carbsGMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_carbsGMeta);
+    }
+    if (data.containsKey('sugar_g')) {
+      context.handle(
+        _sugarGMeta,
+        sugarG.isAcceptableOrUnknown(data['sugar_g']!, _sugarGMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_sugarGMeta);
+    }
+    if (data.containsKey('fiber_g')) {
+      context.handle(
+        _fiberGMeta,
+        fiberG.isAcceptableOrUnknown(data['fiber_g']!, _fiberGMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_fiberGMeta);
+    }
+    if (data.containsKey('protein_g')) {
+      context.handle(
+        _proteinGMeta,
+        proteinG.isAcceptableOrUnknown(data['protein_g']!, _proteinGMeta),
+      );
+    } else if (isInserting) {
+      context.missing(_proteinGMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  CustomFood map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return CustomFood(
+      id: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}id'],
+      )!,
+      name: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}name'],
+      )!,
+      brand: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}brand'],
+      ),
+      barcode: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}barcode'],
+      ),
+      servingSize: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}serving_size'],
+      )!,
+      servingUnit: attachedDatabase.typeMapping.read(
+        DriftSqlType.string,
+        data['${effectivePrefix}serving_unit'],
+      )!,
+      calories: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}calories'],
+      )!,
+      fatG: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}fat_g'],
+      )!,
+      carbsG: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}carbs_g'],
+      )!,
+      sugarG: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}sugar_g'],
+      )!,
+      fiberG: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}fiber_g'],
+      )!,
+      proteinG: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}protein_g'],
+      )!,
+    );
+  }
+
+  @override
+  $CustomFoodsTable createAlias(String alias) {
+    return $CustomFoodsTable(attachedDatabase, alias);
+  }
+}
+
+class CustomFood extends DataClass implements Insertable<CustomFood> {
+  final int id;
+
+  /// Required display name, e.g. "Greek yogurt".
+  final String name;
+
+  /// Optional, e.g. "Chobani".
+  final String? brand;
+
+  /// Optional, normalized digits (EAN-13 if present).
+  final String? barcode;
+
+  /// Serving size amount (in [servingUnit]).
+  final double servingSize;
+
+  /// 'g' | 'ml'
+  final String servingUnit;
+
+  /// Nutrition per serving.
+  final double calories;
+  final double fatG;
+  final double carbsG;
+  final double sugarG;
+  final double fiberG;
+  final double proteinG;
+  const CustomFood({
+    required this.id,
+    required this.name,
+    this.brand,
+    this.barcode,
+    required this.servingSize,
+    required this.servingUnit,
+    required this.calories,
+    required this.fatG,
+    required this.carbsG,
+    required this.sugarG,
+    required this.fiberG,
+    required this.proteinG,
+  });
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<int>(id);
+    map['name'] = Variable<String>(name);
+    if (!nullToAbsent || brand != null) {
+      map['brand'] = Variable<String>(brand);
+    }
+    if (!nullToAbsent || barcode != null) {
+      map['barcode'] = Variable<String>(barcode);
+    }
+    map['serving_size'] = Variable<double>(servingSize);
+    map['serving_unit'] = Variable<String>(servingUnit);
+    map['calories'] = Variable<double>(calories);
+    map['fat_g'] = Variable<double>(fatG);
+    map['carbs_g'] = Variable<double>(carbsG);
+    map['sugar_g'] = Variable<double>(sugarG);
+    map['fiber_g'] = Variable<double>(fiberG);
+    map['protein_g'] = Variable<double>(proteinG);
+    return map;
+  }
+
+  CustomFoodsCompanion toCompanion(bool nullToAbsent) {
+    return CustomFoodsCompanion(
+      id: Value(id),
+      name: Value(name),
+      brand: brand == null && nullToAbsent
+          ? const Value.absent()
+          : Value(brand),
+      barcode: barcode == null && nullToAbsent
+          ? const Value.absent()
+          : Value(barcode),
+      servingSize: Value(servingSize),
+      servingUnit: Value(servingUnit),
+      calories: Value(calories),
+      fatG: Value(fatG),
+      carbsG: Value(carbsG),
+      sugarG: Value(sugarG),
+      fiberG: Value(fiberG),
+      proteinG: Value(proteinG),
+    );
+  }
+
+  factory CustomFood.fromJson(
+    Map<String, dynamic> json, {
+    ValueSerializer? serializer,
+  }) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return CustomFood(
+      id: serializer.fromJson<int>(json['id']),
+      name: serializer.fromJson<String>(json['name']),
+      brand: serializer.fromJson<String?>(json['brand']),
+      barcode: serializer.fromJson<String?>(json['barcode']),
+      servingSize: serializer.fromJson<double>(json['servingSize']),
+      servingUnit: serializer.fromJson<String>(json['servingUnit']),
+      calories: serializer.fromJson<double>(json['calories']),
+      fatG: serializer.fromJson<double>(json['fatG']),
+      carbsG: serializer.fromJson<double>(json['carbsG']),
+      sugarG: serializer.fromJson<double>(json['sugarG']),
+      fiberG: serializer.fromJson<double>(json['fiberG']),
+      proteinG: serializer.fromJson<double>(json['proteinG']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<int>(id),
+      'name': serializer.toJson<String>(name),
+      'brand': serializer.toJson<String?>(brand),
+      'barcode': serializer.toJson<String?>(barcode),
+      'servingSize': serializer.toJson<double>(servingSize),
+      'servingUnit': serializer.toJson<String>(servingUnit),
+      'calories': serializer.toJson<double>(calories),
+      'fatG': serializer.toJson<double>(fatG),
+      'carbsG': serializer.toJson<double>(carbsG),
+      'sugarG': serializer.toJson<double>(sugarG),
+      'fiberG': serializer.toJson<double>(fiberG),
+      'proteinG': serializer.toJson<double>(proteinG),
+    };
+  }
+
+  CustomFood copyWith({
+    int? id,
+    String? name,
+    Value<String?> brand = const Value.absent(),
+    Value<String?> barcode = const Value.absent(),
+    double? servingSize,
+    String? servingUnit,
+    double? calories,
+    double? fatG,
+    double? carbsG,
+    double? sugarG,
+    double? fiberG,
+    double? proteinG,
+  }) => CustomFood(
+    id: id ?? this.id,
+    name: name ?? this.name,
+    brand: brand.present ? brand.value : this.brand,
+    barcode: barcode.present ? barcode.value : this.barcode,
+    servingSize: servingSize ?? this.servingSize,
+    servingUnit: servingUnit ?? this.servingUnit,
+    calories: calories ?? this.calories,
+    fatG: fatG ?? this.fatG,
+    carbsG: carbsG ?? this.carbsG,
+    sugarG: sugarG ?? this.sugarG,
+    fiberG: fiberG ?? this.fiberG,
+    proteinG: proteinG ?? this.proteinG,
+  );
+  CustomFood copyWithCompanion(CustomFoodsCompanion data) {
+    return CustomFood(
+      id: data.id.present ? data.id.value : this.id,
+      name: data.name.present ? data.name.value : this.name,
+      brand: data.brand.present ? data.brand.value : this.brand,
+      barcode: data.barcode.present ? data.barcode.value : this.barcode,
+      servingSize: data.servingSize.present
+          ? data.servingSize.value
+          : this.servingSize,
+      servingUnit: data.servingUnit.present
+          ? data.servingUnit.value
+          : this.servingUnit,
+      calories: data.calories.present ? data.calories.value : this.calories,
+      fatG: data.fatG.present ? data.fatG.value : this.fatG,
+      carbsG: data.carbsG.present ? data.carbsG.value : this.carbsG,
+      sugarG: data.sugarG.present ? data.sugarG.value : this.sugarG,
+      fiberG: data.fiberG.present ? data.fiberG.value : this.fiberG,
+      proteinG: data.proteinG.present ? data.proteinG.value : this.proteinG,
+    );
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CustomFood(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('brand: $brand, ')
+          ..write('barcode: $barcode, ')
+          ..write('servingSize: $servingSize, ')
+          ..write('servingUnit: $servingUnit, ')
+          ..write('calories: $calories, ')
+          ..write('fatG: $fatG, ')
+          ..write('carbsG: $carbsG, ')
+          ..write('sugarG: $sugarG, ')
+          ..write('fiberG: $fiberG, ')
+          ..write('proteinG: $proteinG')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(
+    id,
+    name,
+    brand,
+    barcode,
+    servingSize,
+    servingUnit,
+    calories,
+    fatG,
+    carbsG,
+    sugarG,
+    fiberG,
+    proteinG,
+  );
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is CustomFood &&
+          other.id == this.id &&
+          other.name == this.name &&
+          other.brand == this.brand &&
+          other.barcode == this.barcode &&
+          other.servingSize == this.servingSize &&
+          other.servingUnit == this.servingUnit &&
+          other.calories == this.calories &&
+          other.fatG == this.fatG &&
+          other.carbsG == this.carbsG &&
+          other.sugarG == this.sugarG &&
+          other.fiberG == this.fiberG &&
+          other.proteinG == this.proteinG);
+}
+
+class CustomFoodsCompanion extends UpdateCompanion<CustomFood> {
+  final Value<int> id;
+  final Value<String> name;
+  final Value<String?> brand;
+  final Value<String?> barcode;
+  final Value<double> servingSize;
+  final Value<String> servingUnit;
+  final Value<double> calories;
+  final Value<double> fatG;
+  final Value<double> carbsG;
+  final Value<double> sugarG;
+  final Value<double> fiberG;
+  final Value<double> proteinG;
+  const CustomFoodsCompanion({
+    this.id = const Value.absent(),
+    this.name = const Value.absent(),
+    this.brand = const Value.absent(),
+    this.barcode = const Value.absent(),
+    this.servingSize = const Value.absent(),
+    this.servingUnit = const Value.absent(),
+    this.calories = const Value.absent(),
+    this.fatG = const Value.absent(),
+    this.carbsG = const Value.absent(),
+    this.sugarG = const Value.absent(),
+    this.fiberG = const Value.absent(),
+    this.proteinG = const Value.absent(),
+  });
+  CustomFoodsCompanion.insert({
+    this.id = const Value.absent(),
+    required String name,
+    this.brand = const Value.absent(),
+    this.barcode = const Value.absent(),
+    required double servingSize,
+    required String servingUnit,
+    required double calories,
+    required double fatG,
+    required double carbsG,
+    required double sugarG,
+    required double fiberG,
+    required double proteinG,
+  }) : name = Value(name),
+       servingSize = Value(servingSize),
+       servingUnit = Value(servingUnit),
+       calories = Value(calories),
+       fatG = Value(fatG),
+       carbsG = Value(carbsG),
+       sugarG = Value(sugarG),
+       fiberG = Value(fiberG),
+       proteinG = Value(proteinG);
+  static Insertable<CustomFood> custom({
+    Expression<int>? id,
+    Expression<String>? name,
+    Expression<String>? brand,
+    Expression<String>? barcode,
+    Expression<double>? servingSize,
+    Expression<String>? servingUnit,
+    Expression<double>? calories,
+    Expression<double>? fatG,
+    Expression<double>? carbsG,
+    Expression<double>? sugarG,
+    Expression<double>? fiberG,
+    Expression<double>? proteinG,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (name != null) 'name': name,
+      if (brand != null) 'brand': brand,
+      if (barcode != null) 'barcode': barcode,
+      if (servingSize != null) 'serving_size': servingSize,
+      if (servingUnit != null) 'serving_unit': servingUnit,
+      if (calories != null) 'calories': calories,
+      if (fatG != null) 'fat_g': fatG,
+      if (carbsG != null) 'carbs_g': carbsG,
+      if (sugarG != null) 'sugar_g': sugarG,
+      if (fiberG != null) 'fiber_g': fiberG,
+      if (proteinG != null) 'protein_g': proteinG,
+    });
+  }
+
+  CustomFoodsCompanion copyWith({
+    Value<int>? id,
+    Value<String>? name,
+    Value<String?>? brand,
+    Value<String?>? barcode,
+    Value<double>? servingSize,
+    Value<String>? servingUnit,
+    Value<double>? calories,
+    Value<double>? fatG,
+    Value<double>? carbsG,
+    Value<double>? sugarG,
+    Value<double>? fiberG,
+    Value<double>? proteinG,
+  }) {
+    return CustomFoodsCompanion(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      brand: brand ?? this.brand,
+      barcode: barcode ?? this.barcode,
+      servingSize: servingSize ?? this.servingSize,
+      servingUnit: servingUnit ?? this.servingUnit,
+      calories: calories ?? this.calories,
+      fatG: fatG ?? this.fatG,
+      carbsG: carbsG ?? this.carbsG,
+      sugarG: sugarG ?? this.sugarG,
+      fiberG: fiberG ?? this.fiberG,
+      proteinG: proteinG ?? this.proteinG,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<int>(id.value);
+    }
+    if (name.present) {
+      map['name'] = Variable<String>(name.value);
+    }
+    if (brand.present) {
+      map['brand'] = Variable<String>(brand.value);
+    }
+    if (barcode.present) {
+      map['barcode'] = Variable<String>(barcode.value);
+    }
+    if (servingSize.present) {
+      map['serving_size'] = Variable<double>(servingSize.value);
+    }
+    if (servingUnit.present) {
+      map['serving_unit'] = Variable<String>(servingUnit.value);
+    }
+    if (calories.present) {
+      map['calories'] = Variable<double>(calories.value);
+    }
+    if (fatG.present) {
+      map['fat_g'] = Variable<double>(fatG.value);
+    }
+    if (carbsG.present) {
+      map['carbs_g'] = Variable<double>(carbsG.value);
+    }
+    if (sugarG.present) {
+      map['sugar_g'] = Variable<double>(sugarG.value);
+    }
+    if (fiberG.present) {
+      map['fiber_g'] = Variable<double>(fiberG.value);
+    }
+    if (proteinG.present) {
+      map['protein_g'] = Variable<double>(proteinG.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('CustomFoodsCompanion(')
+          ..write('id: $id, ')
+          ..write('name: $name, ')
+          ..write('brand: $brand, ')
+          ..write('barcode: $barcode, ')
+          ..write('servingSize: $servingSize, ')
+          ..write('servingUnit: $servingUnit, ')
+          ..write('calories: $calories, ')
+          ..write('fatG: $fatG, ')
+          ..write('carbsG: $carbsG, ')
+          ..write('sugarG: $sugarG, ')
+          ..write('fiberG: $fiberG, ')
+          ..write('proteinG: $proteinG')
+          ..write(')'))
+        .toString();
+  }
+}
+
 class $FoodLogEntriesTable extends FoodLogEntries
     with TableInfo<$FoodLogEntriesTable, FoodLogEntry> {
   @override
@@ -1499,6 +2205,17 @@ class $FoodLogEntriesTable extends FoodLogEntries
     aliasedName,
     true,
     type: DriftSqlType.string,
+    requiredDuringInsert: false,
+  );
+  static const VerificationMeta _customFoodIdMeta = const VerificationMeta(
+    'customFoodId',
+  );
+  @override
+  late final GeneratedColumn<int> customFoodId = GeneratedColumn<int>(
+    'custom_food_id',
+    aliasedName,
+    true,
+    type: DriftSqlType.int,
     requiredDuringInsert: false,
   );
   static const VerificationMeta _displayNameMeta = const VerificationMeta(
@@ -1550,6 +2267,26 @@ class $FoodLogEntriesTable extends FoodLogEntries
     type: DriftSqlType.double,
     requiredDuringInsert: true,
   );
+  static const VerificationMeta _sugarGMeta = const VerificationMeta('sugarG');
+  @override
+  late final GeneratedColumn<double> sugarG = GeneratedColumn<double>(
+    'sugar_g',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
+  static const VerificationMeta _fiberGMeta = const VerificationMeta('fiberG');
+  @override
+  late final GeneratedColumn<double> fiberG = GeneratedColumn<double>(
+    'fiber_g',
+    aliasedName,
+    false,
+    type: DriftSqlType.double,
+    requiredDuringInsert: false,
+    defaultValue: const Constant(0),
+  );
   static const VerificationMeta _fatGMeta = const VerificationMeta('fatG');
   @override
   late final GeneratedColumn<double> fatG = GeneratedColumn<double>(
@@ -1565,11 +2302,14 @@ class $FoodLogEntriesTable extends FoodLogEntries
     loggedAt,
     source,
     catalogFoodId,
+    customFoodId,
     displayName,
     grams,
     kcal,
     proteinG,
     carbsG,
+    sugarG,
+    fiberG,
     fatG,
   ];
   @override
@@ -1609,6 +2349,15 @@ class $FoodLogEntriesTable extends FoodLogEntries
         catalogFoodId.isAcceptableOrUnknown(
           data['catalog_food_id']!,
           _catalogFoodIdMeta,
+        ),
+      );
+    }
+    if (data.containsKey('custom_food_id')) {
+      context.handle(
+        _customFoodIdMeta,
+        customFoodId.isAcceptableOrUnknown(
+          data['custom_food_id']!,
+          _customFoodIdMeta,
         ),
       );
     }
@@ -1655,6 +2404,18 @@ class $FoodLogEntriesTable extends FoodLogEntries
     } else if (isInserting) {
       context.missing(_carbsGMeta);
     }
+    if (data.containsKey('sugar_g')) {
+      context.handle(
+        _sugarGMeta,
+        sugarG.isAcceptableOrUnknown(data['sugar_g']!, _sugarGMeta),
+      );
+    }
+    if (data.containsKey('fiber_g')) {
+      context.handle(
+        _fiberGMeta,
+        fiberG.isAcceptableOrUnknown(data['fiber_g']!, _fiberGMeta),
+      );
+    }
     if (data.containsKey('fat_g')) {
       context.handle(
         _fatGMeta,
@@ -1688,6 +2449,10 @@ class $FoodLogEntriesTable extends FoodLogEntries
         DriftSqlType.string,
         data['${effectivePrefix}catalog_food_id'],
       ),
+      customFoodId: attachedDatabase.typeMapping.read(
+        DriftSqlType.int,
+        data['${effectivePrefix}custom_food_id'],
+      ),
       displayName: attachedDatabase.typeMapping.read(
         DriftSqlType.string,
         data['${effectivePrefix}display_name'],
@@ -1708,6 +2473,14 @@ class $FoodLogEntriesTable extends FoodLogEntries
         DriftSqlType.double,
         data['${effectivePrefix}carbs_g'],
       )!,
+      sugarG: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}sugar_g'],
+      )!,
+      fiberG: attachedDatabase.typeMapping.read(
+        DriftSqlType.double,
+        data['${effectivePrefix}fiber_g'],
+      )!,
       fatG: attachedDatabase.typeMapping.read(
         DriftSqlType.double,
         data['${effectivePrefix}fat_g'],
@@ -1726,22 +2499,28 @@ class FoodLogEntry extends DataClass implements Insertable<FoodLogEntry> {
   final DateTime loggedAt;
   final String source;
   final String? catalogFoodId;
+  final int? customFoodId;
   final String displayName;
   final double grams;
   final double kcal;
   final double proteinG;
   final double carbsG;
+  final double sugarG;
+  final double fiberG;
   final double fatG;
   const FoodLogEntry({
     required this.id,
     required this.loggedAt,
     required this.source,
     this.catalogFoodId,
+    this.customFoodId,
     required this.displayName,
     required this.grams,
     required this.kcal,
     required this.proteinG,
     required this.carbsG,
+    required this.sugarG,
+    required this.fiberG,
     required this.fatG,
   });
   @override
@@ -1753,11 +2532,16 @@ class FoodLogEntry extends DataClass implements Insertable<FoodLogEntry> {
     if (!nullToAbsent || catalogFoodId != null) {
       map['catalog_food_id'] = Variable<String>(catalogFoodId);
     }
+    if (!nullToAbsent || customFoodId != null) {
+      map['custom_food_id'] = Variable<int>(customFoodId);
+    }
     map['display_name'] = Variable<String>(displayName);
     map['grams'] = Variable<double>(grams);
     map['kcal'] = Variable<double>(kcal);
     map['protein_g'] = Variable<double>(proteinG);
     map['carbs_g'] = Variable<double>(carbsG);
+    map['sugar_g'] = Variable<double>(sugarG);
+    map['fiber_g'] = Variable<double>(fiberG);
     map['fat_g'] = Variable<double>(fatG);
     return map;
   }
@@ -1770,11 +2554,16 @@ class FoodLogEntry extends DataClass implements Insertable<FoodLogEntry> {
       catalogFoodId: catalogFoodId == null && nullToAbsent
           ? const Value.absent()
           : Value(catalogFoodId),
+      customFoodId: customFoodId == null && nullToAbsent
+          ? const Value.absent()
+          : Value(customFoodId),
       displayName: Value(displayName),
       grams: Value(grams),
       kcal: Value(kcal),
       proteinG: Value(proteinG),
       carbsG: Value(carbsG),
+      sugarG: Value(sugarG),
+      fiberG: Value(fiberG),
       fatG: Value(fatG),
     );
   }
@@ -1789,11 +2578,14 @@ class FoodLogEntry extends DataClass implements Insertable<FoodLogEntry> {
       loggedAt: serializer.fromJson<DateTime>(json['loggedAt']),
       source: serializer.fromJson<String>(json['source']),
       catalogFoodId: serializer.fromJson<String?>(json['catalogFoodId']),
+      customFoodId: serializer.fromJson<int?>(json['customFoodId']),
       displayName: serializer.fromJson<String>(json['displayName']),
       grams: serializer.fromJson<double>(json['grams']),
       kcal: serializer.fromJson<double>(json['kcal']),
       proteinG: serializer.fromJson<double>(json['proteinG']),
       carbsG: serializer.fromJson<double>(json['carbsG']),
+      sugarG: serializer.fromJson<double>(json['sugarG']),
+      fiberG: serializer.fromJson<double>(json['fiberG']),
       fatG: serializer.fromJson<double>(json['fatG']),
     );
   }
@@ -1805,11 +2597,14 @@ class FoodLogEntry extends DataClass implements Insertable<FoodLogEntry> {
       'loggedAt': serializer.toJson<DateTime>(loggedAt),
       'source': serializer.toJson<String>(source),
       'catalogFoodId': serializer.toJson<String?>(catalogFoodId),
+      'customFoodId': serializer.toJson<int?>(customFoodId),
       'displayName': serializer.toJson<String>(displayName),
       'grams': serializer.toJson<double>(grams),
       'kcal': serializer.toJson<double>(kcal),
       'proteinG': serializer.toJson<double>(proteinG),
       'carbsG': serializer.toJson<double>(carbsG),
+      'sugarG': serializer.toJson<double>(sugarG),
+      'fiberG': serializer.toJson<double>(fiberG),
       'fatG': serializer.toJson<double>(fatG),
     };
   }
@@ -1819,11 +2614,14 @@ class FoodLogEntry extends DataClass implements Insertable<FoodLogEntry> {
     DateTime? loggedAt,
     String? source,
     Value<String?> catalogFoodId = const Value.absent(),
+    Value<int?> customFoodId = const Value.absent(),
     String? displayName,
     double? grams,
     double? kcal,
     double? proteinG,
     double? carbsG,
+    double? sugarG,
+    double? fiberG,
     double? fatG,
   }) => FoodLogEntry(
     id: id ?? this.id,
@@ -1832,11 +2630,14 @@ class FoodLogEntry extends DataClass implements Insertable<FoodLogEntry> {
     catalogFoodId: catalogFoodId.present
         ? catalogFoodId.value
         : this.catalogFoodId,
+    customFoodId: customFoodId.present ? customFoodId.value : this.customFoodId,
     displayName: displayName ?? this.displayName,
     grams: grams ?? this.grams,
     kcal: kcal ?? this.kcal,
     proteinG: proteinG ?? this.proteinG,
     carbsG: carbsG ?? this.carbsG,
+    sugarG: sugarG ?? this.sugarG,
+    fiberG: fiberG ?? this.fiberG,
     fatG: fatG ?? this.fatG,
   );
   FoodLogEntry copyWithCompanion(FoodLogEntriesCompanion data) {
@@ -1847,6 +2648,9 @@ class FoodLogEntry extends DataClass implements Insertable<FoodLogEntry> {
       catalogFoodId: data.catalogFoodId.present
           ? data.catalogFoodId.value
           : this.catalogFoodId,
+      customFoodId: data.customFoodId.present
+          ? data.customFoodId.value
+          : this.customFoodId,
       displayName: data.displayName.present
           ? data.displayName.value
           : this.displayName,
@@ -1854,6 +2658,8 @@ class FoodLogEntry extends DataClass implements Insertable<FoodLogEntry> {
       kcal: data.kcal.present ? data.kcal.value : this.kcal,
       proteinG: data.proteinG.present ? data.proteinG.value : this.proteinG,
       carbsG: data.carbsG.present ? data.carbsG.value : this.carbsG,
+      sugarG: data.sugarG.present ? data.sugarG.value : this.sugarG,
+      fiberG: data.fiberG.present ? data.fiberG.value : this.fiberG,
       fatG: data.fatG.present ? data.fatG.value : this.fatG,
     );
   }
@@ -1865,11 +2671,14 @@ class FoodLogEntry extends DataClass implements Insertable<FoodLogEntry> {
           ..write('loggedAt: $loggedAt, ')
           ..write('source: $source, ')
           ..write('catalogFoodId: $catalogFoodId, ')
+          ..write('customFoodId: $customFoodId, ')
           ..write('displayName: $displayName, ')
           ..write('grams: $grams, ')
           ..write('kcal: $kcal, ')
           ..write('proteinG: $proteinG, ')
           ..write('carbsG: $carbsG, ')
+          ..write('sugarG: $sugarG, ')
+          ..write('fiberG: $fiberG, ')
           ..write('fatG: $fatG')
           ..write(')'))
         .toString();
@@ -1881,11 +2690,14 @@ class FoodLogEntry extends DataClass implements Insertable<FoodLogEntry> {
     loggedAt,
     source,
     catalogFoodId,
+    customFoodId,
     displayName,
     grams,
     kcal,
     proteinG,
     carbsG,
+    sugarG,
+    fiberG,
     fatG,
   );
   @override
@@ -1896,11 +2708,14 @@ class FoodLogEntry extends DataClass implements Insertable<FoodLogEntry> {
           other.loggedAt == this.loggedAt &&
           other.source == this.source &&
           other.catalogFoodId == this.catalogFoodId &&
+          other.customFoodId == this.customFoodId &&
           other.displayName == this.displayName &&
           other.grams == this.grams &&
           other.kcal == this.kcal &&
           other.proteinG == this.proteinG &&
           other.carbsG == this.carbsG &&
+          other.sugarG == this.sugarG &&
+          other.fiberG == this.fiberG &&
           other.fatG == this.fatG);
 }
 
@@ -1909,22 +2724,28 @@ class FoodLogEntriesCompanion extends UpdateCompanion<FoodLogEntry> {
   final Value<DateTime> loggedAt;
   final Value<String> source;
   final Value<String?> catalogFoodId;
+  final Value<int?> customFoodId;
   final Value<String> displayName;
   final Value<double> grams;
   final Value<double> kcal;
   final Value<double> proteinG;
   final Value<double> carbsG;
+  final Value<double> sugarG;
+  final Value<double> fiberG;
   final Value<double> fatG;
   const FoodLogEntriesCompanion({
     this.id = const Value.absent(),
     this.loggedAt = const Value.absent(),
     this.source = const Value.absent(),
     this.catalogFoodId = const Value.absent(),
+    this.customFoodId = const Value.absent(),
     this.displayName = const Value.absent(),
     this.grams = const Value.absent(),
     this.kcal = const Value.absent(),
     this.proteinG = const Value.absent(),
     this.carbsG = const Value.absent(),
+    this.sugarG = const Value.absent(),
+    this.fiberG = const Value.absent(),
     this.fatG = const Value.absent(),
   });
   FoodLogEntriesCompanion.insert({
@@ -1932,11 +2753,14 @@ class FoodLogEntriesCompanion extends UpdateCompanion<FoodLogEntry> {
     required DateTime loggedAt,
     required String source,
     this.catalogFoodId = const Value.absent(),
+    this.customFoodId = const Value.absent(),
     required String displayName,
     required double grams,
     required double kcal,
     required double proteinG,
     required double carbsG,
+    this.sugarG = const Value.absent(),
+    this.fiberG = const Value.absent(),
     required double fatG,
   }) : loggedAt = Value(loggedAt),
        source = Value(source),
@@ -1951,11 +2775,14 @@ class FoodLogEntriesCompanion extends UpdateCompanion<FoodLogEntry> {
     Expression<DateTime>? loggedAt,
     Expression<String>? source,
     Expression<String>? catalogFoodId,
+    Expression<int>? customFoodId,
     Expression<String>? displayName,
     Expression<double>? grams,
     Expression<double>? kcal,
     Expression<double>? proteinG,
     Expression<double>? carbsG,
+    Expression<double>? sugarG,
+    Expression<double>? fiberG,
     Expression<double>? fatG,
   }) {
     return RawValuesInsertable({
@@ -1963,11 +2790,14 @@ class FoodLogEntriesCompanion extends UpdateCompanion<FoodLogEntry> {
       if (loggedAt != null) 'logged_at': loggedAt,
       if (source != null) 'source': source,
       if (catalogFoodId != null) 'catalog_food_id': catalogFoodId,
+      if (customFoodId != null) 'custom_food_id': customFoodId,
       if (displayName != null) 'display_name': displayName,
       if (grams != null) 'grams': grams,
       if (kcal != null) 'kcal': kcal,
       if (proteinG != null) 'protein_g': proteinG,
       if (carbsG != null) 'carbs_g': carbsG,
+      if (sugarG != null) 'sugar_g': sugarG,
+      if (fiberG != null) 'fiber_g': fiberG,
       if (fatG != null) 'fat_g': fatG,
     });
   }
@@ -1977,11 +2807,14 @@ class FoodLogEntriesCompanion extends UpdateCompanion<FoodLogEntry> {
     Value<DateTime>? loggedAt,
     Value<String>? source,
     Value<String?>? catalogFoodId,
+    Value<int?>? customFoodId,
     Value<String>? displayName,
     Value<double>? grams,
     Value<double>? kcal,
     Value<double>? proteinG,
     Value<double>? carbsG,
+    Value<double>? sugarG,
+    Value<double>? fiberG,
     Value<double>? fatG,
   }) {
     return FoodLogEntriesCompanion(
@@ -1989,11 +2822,14 @@ class FoodLogEntriesCompanion extends UpdateCompanion<FoodLogEntry> {
       loggedAt: loggedAt ?? this.loggedAt,
       source: source ?? this.source,
       catalogFoodId: catalogFoodId ?? this.catalogFoodId,
+      customFoodId: customFoodId ?? this.customFoodId,
       displayName: displayName ?? this.displayName,
       grams: grams ?? this.grams,
       kcal: kcal ?? this.kcal,
       proteinG: proteinG ?? this.proteinG,
       carbsG: carbsG ?? this.carbsG,
+      sugarG: sugarG ?? this.sugarG,
+      fiberG: fiberG ?? this.fiberG,
       fatG: fatG ?? this.fatG,
     );
   }
@@ -2013,6 +2849,9 @@ class FoodLogEntriesCompanion extends UpdateCompanion<FoodLogEntry> {
     if (catalogFoodId.present) {
       map['catalog_food_id'] = Variable<String>(catalogFoodId.value);
     }
+    if (customFoodId.present) {
+      map['custom_food_id'] = Variable<int>(customFoodId.value);
+    }
     if (displayName.present) {
       map['display_name'] = Variable<String>(displayName.value);
     }
@@ -2028,6 +2867,12 @@ class FoodLogEntriesCompanion extends UpdateCompanion<FoodLogEntry> {
     if (carbsG.present) {
       map['carbs_g'] = Variable<double>(carbsG.value);
     }
+    if (sugarG.present) {
+      map['sugar_g'] = Variable<double>(sugarG.value);
+    }
+    if (fiberG.present) {
+      map['fiber_g'] = Variable<double>(fiberG.value);
+    }
     if (fatG.present) {
       map['fat_g'] = Variable<double>(fatG.value);
     }
@@ -2041,11 +2886,14 @@ class FoodLogEntriesCompanion extends UpdateCompanion<FoodLogEntry> {
           ..write('loggedAt: $loggedAt, ')
           ..write('source: $source, ')
           ..write('catalogFoodId: $catalogFoodId, ')
+          ..write('customFoodId: $customFoodId, ')
           ..write('displayName: $displayName, ')
           ..write('grams: $grams, ')
           ..write('kcal: $kcal, ')
           ..write('proteinG: $proteinG, ')
           ..write('carbsG: $carbsG, ')
+          ..write('sugarG: $sugarG, ')
+          ..write('fiberG: $fiberG, ')
           ..write('fatG: $fatG')
           ..write(')'))
         .toString();
@@ -2058,6 +2906,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
   late final $ProfilesTable profiles = $ProfilesTable(this);
   late final $GoalsTable goals = $GoalsTable(this);
   late final $WeightEntriesTable weightEntries = $WeightEntriesTable(this);
+  late final $CustomFoodsTable customFoods = $CustomFoodsTable(this);
   late final $FoodLogEntriesTable foodLogEntries = $FoodLogEntriesTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
@@ -2067,6 +2916,7 @@ abstract class _$AppDatabase extends GeneratedDatabase {
     profiles,
     goals,
     weightEntries,
+    customFoods,
     foodLogEntries,
   ];
 }
@@ -2797,17 +3647,351 @@ typedef $$WeightEntriesTableProcessedTableManager =
       WeightEntry,
       PrefetchHooks Function()
     >;
+typedef $$CustomFoodsTableCreateCompanionBuilder =
+    CustomFoodsCompanion Function({
+      Value<int> id,
+      required String name,
+      Value<String?> brand,
+      Value<String?> barcode,
+      required double servingSize,
+      required String servingUnit,
+      required double calories,
+      required double fatG,
+      required double carbsG,
+      required double sugarG,
+      required double fiberG,
+      required double proteinG,
+    });
+typedef $$CustomFoodsTableUpdateCompanionBuilder =
+    CustomFoodsCompanion Function({
+      Value<int> id,
+      Value<String> name,
+      Value<String?> brand,
+      Value<String?> barcode,
+      Value<double> servingSize,
+      Value<String> servingUnit,
+      Value<double> calories,
+      Value<double> fatG,
+      Value<double> carbsG,
+      Value<double> sugarG,
+      Value<double> fiberG,
+      Value<double> proteinG,
+    });
+
+class $$CustomFoodsTableFilterComposer
+    extends Composer<_$AppDatabase, $CustomFoodsTable> {
+  $$CustomFoodsTableFilterComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnFilters<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get brand => $composableBuilder(
+    column: $table.brand,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get barcode => $composableBuilder(
+    column: $table.barcode,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get servingSize => $composableBuilder(
+    column: $table.servingSize,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<String> get servingUnit => $composableBuilder(
+    column: $table.servingUnit,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get calories => $composableBuilder(
+    column: $table.calories,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get fatG => $composableBuilder(
+    column: $table.fatG,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get carbsG => $composableBuilder(
+    column: $table.carbsG,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get sugarG => $composableBuilder(
+    column: $table.sugarG,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get fiberG => $composableBuilder(
+    column: $table.fiberG,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get proteinG => $composableBuilder(
+    column: $table.proteinG,
+    builder: (column) => ColumnFilters(column),
+  );
+}
+
+class $$CustomFoodsTableOrderingComposer
+    extends Composer<_$AppDatabase, $CustomFoodsTable> {
+  $$CustomFoodsTableOrderingComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  ColumnOrderings<int> get id => $composableBuilder(
+    column: $table.id,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get name => $composableBuilder(
+    column: $table.name,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get brand => $composableBuilder(
+    column: $table.brand,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get barcode => $composableBuilder(
+    column: $table.barcode,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get servingSize => $composableBuilder(
+    column: $table.servingSize,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<String> get servingUnit => $composableBuilder(
+    column: $table.servingUnit,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get calories => $composableBuilder(
+    column: $table.calories,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get fatG => $composableBuilder(
+    column: $table.fatG,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get carbsG => $composableBuilder(
+    column: $table.carbsG,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get sugarG => $composableBuilder(
+    column: $table.sugarG,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get fiberG => $composableBuilder(
+    column: $table.fiberG,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get proteinG => $composableBuilder(
+    column: $table.proteinG,
+    builder: (column) => ColumnOrderings(column),
+  );
+}
+
+class $$CustomFoodsTableAnnotationComposer
+    extends Composer<_$AppDatabase, $CustomFoodsTable> {
+  $$CustomFoodsTableAnnotationComposer({
+    required super.$db,
+    required super.$table,
+    super.joinBuilder,
+    super.$addJoinBuilderToRootComposer,
+    super.$removeJoinBuilderFromRootComposer,
+  });
+  GeneratedColumn<int> get id =>
+      $composableBuilder(column: $table.id, builder: (column) => column);
+
+  GeneratedColumn<String> get name =>
+      $composableBuilder(column: $table.name, builder: (column) => column);
+
+  GeneratedColumn<String> get brand =>
+      $composableBuilder(column: $table.brand, builder: (column) => column);
+
+  GeneratedColumn<String> get barcode =>
+      $composableBuilder(column: $table.barcode, builder: (column) => column);
+
+  GeneratedColumn<double> get servingSize => $composableBuilder(
+    column: $table.servingSize,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<String> get servingUnit => $composableBuilder(
+    column: $table.servingUnit,
+    builder: (column) => column,
+  );
+
+  GeneratedColumn<double> get calories =>
+      $composableBuilder(column: $table.calories, builder: (column) => column);
+
+  GeneratedColumn<double> get fatG =>
+      $composableBuilder(column: $table.fatG, builder: (column) => column);
+
+  GeneratedColumn<double> get carbsG =>
+      $composableBuilder(column: $table.carbsG, builder: (column) => column);
+
+  GeneratedColumn<double> get sugarG =>
+      $composableBuilder(column: $table.sugarG, builder: (column) => column);
+
+  GeneratedColumn<double> get fiberG =>
+      $composableBuilder(column: $table.fiberG, builder: (column) => column);
+
+  GeneratedColumn<double> get proteinG =>
+      $composableBuilder(column: $table.proteinG, builder: (column) => column);
+}
+
+class $$CustomFoodsTableTableManager
+    extends
+        RootTableManager<
+          _$AppDatabase,
+          $CustomFoodsTable,
+          CustomFood,
+          $$CustomFoodsTableFilterComposer,
+          $$CustomFoodsTableOrderingComposer,
+          $$CustomFoodsTableAnnotationComposer,
+          $$CustomFoodsTableCreateCompanionBuilder,
+          $$CustomFoodsTableUpdateCompanionBuilder,
+          (
+            CustomFood,
+            BaseReferences<_$AppDatabase, $CustomFoodsTable, CustomFood>,
+          ),
+          CustomFood,
+          PrefetchHooks Function()
+        > {
+  $$CustomFoodsTableTableManager(_$AppDatabase db, $CustomFoodsTable table)
+    : super(
+        TableManagerState(
+          db: db,
+          table: table,
+          createFilteringComposer: () =>
+              $$CustomFoodsTableFilterComposer($db: db, $table: table),
+          createOrderingComposer: () =>
+              $$CustomFoodsTableOrderingComposer($db: db, $table: table),
+          createComputedFieldComposer: () =>
+              $$CustomFoodsTableAnnotationComposer($db: db, $table: table),
+          updateCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                Value<String> name = const Value.absent(),
+                Value<String?> brand = const Value.absent(),
+                Value<String?> barcode = const Value.absent(),
+                Value<double> servingSize = const Value.absent(),
+                Value<String> servingUnit = const Value.absent(),
+                Value<double> calories = const Value.absent(),
+                Value<double> fatG = const Value.absent(),
+                Value<double> carbsG = const Value.absent(),
+                Value<double> sugarG = const Value.absent(),
+                Value<double> fiberG = const Value.absent(),
+                Value<double> proteinG = const Value.absent(),
+              }) => CustomFoodsCompanion(
+                id: id,
+                name: name,
+                brand: brand,
+                barcode: barcode,
+                servingSize: servingSize,
+                servingUnit: servingUnit,
+                calories: calories,
+                fatG: fatG,
+                carbsG: carbsG,
+                sugarG: sugarG,
+                fiberG: fiberG,
+                proteinG: proteinG,
+              ),
+          createCompanionCallback:
+              ({
+                Value<int> id = const Value.absent(),
+                required String name,
+                Value<String?> brand = const Value.absent(),
+                Value<String?> barcode = const Value.absent(),
+                required double servingSize,
+                required String servingUnit,
+                required double calories,
+                required double fatG,
+                required double carbsG,
+                required double sugarG,
+                required double fiberG,
+                required double proteinG,
+              }) => CustomFoodsCompanion.insert(
+                id: id,
+                name: name,
+                brand: brand,
+                barcode: barcode,
+                servingSize: servingSize,
+                servingUnit: servingUnit,
+                calories: calories,
+                fatG: fatG,
+                carbsG: carbsG,
+                sugarG: sugarG,
+                fiberG: fiberG,
+                proteinG: proteinG,
+              ),
+          withReferenceMapper: (p0) => p0
+              .map((e) => (e.readTable(table), BaseReferences(db, table, e)))
+              .toList(),
+          prefetchHooksCallback: null,
+        ),
+      );
+}
+
+typedef $$CustomFoodsTableProcessedTableManager =
+    ProcessedTableManager<
+      _$AppDatabase,
+      $CustomFoodsTable,
+      CustomFood,
+      $$CustomFoodsTableFilterComposer,
+      $$CustomFoodsTableOrderingComposer,
+      $$CustomFoodsTableAnnotationComposer,
+      $$CustomFoodsTableCreateCompanionBuilder,
+      $$CustomFoodsTableUpdateCompanionBuilder,
+      (
+        CustomFood,
+        BaseReferences<_$AppDatabase, $CustomFoodsTable, CustomFood>,
+      ),
+      CustomFood,
+      PrefetchHooks Function()
+    >;
 typedef $$FoodLogEntriesTableCreateCompanionBuilder =
     FoodLogEntriesCompanion Function({
       Value<int> id,
       required DateTime loggedAt,
       required String source,
       Value<String?> catalogFoodId,
+      Value<int?> customFoodId,
       required String displayName,
       required double grams,
       required double kcal,
       required double proteinG,
       required double carbsG,
+      Value<double> sugarG,
+      Value<double> fiberG,
       required double fatG,
     });
 typedef $$FoodLogEntriesTableUpdateCompanionBuilder =
@@ -2816,11 +4000,14 @@ typedef $$FoodLogEntriesTableUpdateCompanionBuilder =
       Value<DateTime> loggedAt,
       Value<String> source,
       Value<String?> catalogFoodId,
+      Value<int?> customFoodId,
       Value<String> displayName,
       Value<double> grams,
       Value<double> kcal,
       Value<double> proteinG,
       Value<double> carbsG,
+      Value<double> sugarG,
+      Value<double> fiberG,
       Value<double> fatG,
     });
 
@@ -2853,6 +4040,11 @@ class $$FoodLogEntriesTableFilterComposer
     builder: (column) => ColumnFilters(column),
   );
 
+  ColumnFilters<int> get customFoodId => $composableBuilder(
+    column: $table.customFoodId,
+    builder: (column) => ColumnFilters(column),
+  );
+
   ColumnFilters<String> get displayName => $composableBuilder(
     column: $table.displayName,
     builder: (column) => ColumnFilters(column),
@@ -2875,6 +4067,16 @@ class $$FoodLogEntriesTableFilterComposer
 
   ColumnFilters<double> get carbsG => $composableBuilder(
     column: $table.carbsG,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get sugarG => $composableBuilder(
+    column: $table.sugarG,
+    builder: (column) => ColumnFilters(column),
+  );
+
+  ColumnFilters<double> get fiberG => $composableBuilder(
+    column: $table.fiberG,
     builder: (column) => ColumnFilters(column),
   );
 
@@ -2913,6 +4115,11 @@ class $$FoodLogEntriesTableOrderingComposer
     builder: (column) => ColumnOrderings(column),
   );
 
+  ColumnOrderings<int> get customFoodId => $composableBuilder(
+    column: $table.customFoodId,
+    builder: (column) => ColumnOrderings(column),
+  );
+
   ColumnOrderings<String> get displayName => $composableBuilder(
     column: $table.displayName,
     builder: (column) => ColumnOrderings(column),
@@ -2935,6 +4142,16 @@ class $$FoodLogEntriesTableOrderingComposer
 
   ColumnOrderings<double> get carbsG => $composableBuilder(
     column: $table.carbsG,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get sugarG => $composableBuilder(
+    column: $table.sugarG,
+    builder: (column) => ColumnOrderings(column),
+  );
+
+  ColumnOrderings<double> get fiberG => $composableBuilder(
+    column: $table.fiberG,
     builder: (column) => ColumnOrderings(column),
   );
 
@@ -2967,6 +4184,11 @@ class $$FoodLogEntriesTableAnnotationComposer
     builder: (column) => column,
   );
 
+  GeneratedColumn<int> get customFoodId => $composableBuilder(
+    column: $table.customFoodId,
+    builder: (column) => column,
+  );
+
   GeneratedColumn<String> get displayName => $composableBuilder(
     column: $table.displayName,
     builder: (column) => column,
@@ -2983,6 +4205,12 @@ class $$FoodLogEntriesTableAnnotationComposer
 
   GeneratedColumn<double> get carbsG =>
       $composableBuilder(column: $table.carbsG, builder: (column) => column);
+
+  GeneratedColumn<double> get sugarG =>
+      $composableBuilder(column: $table.sugarG, builder: (column) => column);
+
+  GeneratedColumn<double> get fiberG =>
+      $composableBuilder(column: $table.fiberG, builder: (column) => column);
 
   GeneratedColumn<double> get fatG =>
       $composableBuilder(column: $table.fatG, builder: (column) => column);
@@ -3025,22 +4253,28 @@ class $$FoodLogEntriesTableTableManager
                 Value<DateTime> loggedAt = const Value.absent(),
                 Value<String> source = const Value.absent(),
                 Value<String?> catalogFoodId = const Value.absent(),
+                Value<int?> customFoodId = const Value.absent(),
                 Value<String> displayName = const Value.absent(),
                 Value<double> grams = const Value.absent(),
                 Value<double> kcal = const Value.absent(),
                 Value<double> proteinG = const Value.absent(),
                 Value<double> carbsG = const Value.absent(),
+                Value<double> sugarG = const Value.absent(),
+                Value<double> fiberG = const Value.absent(),
                 Value<double> fatG = const Value.absent(),
               }) => FoodLogEntriesCompanion(
                 id: id,
                 loggedAt: loggedAt,
                 source: source,
                 catalogFoodId: catalogFoodId,
+                customFoodId: customFoodId,
                 displayName: displayName,
                 grams: grams,
                 kcal: kcal,
                 proteinG: proteinG,
                 carbsG: carbsG,
+                sugarG: sugarG,
+                fiberG: fiberG,
                 fatG: fatG,
               ),
           createCompanionCallback:
@@ -3049,22 +4283,28 @@ class $$FoodLogEntriesTableTableManager
                 required DateTime loggedAt,
                 required String source,
                 Value<String?> catalogFoodId = const Value.absent(),
+                Value<int?> customFoodId = const Value.absent(),
                 required String displayName,
                 required double grams,
                 required double kcal,
                 required double proteinG,
                 required double carbsG,
+                Value<double> sugarG = const Value.absent(),
+                Value<double> fiberG = const Value.absent(),
                 required double fatG,
               }) => FoodLogEntriesCompanion.insert(
                 id: id,
                 loggedAt: loggedAt,
                 source: source,
                 catalogFoodId: catalogFoodId,
+                customFoodId: customFoodId,
                 displayName: displayName,
                 grams: grams,
                 kcal: kcal,
                 proteinG: proteinG,
                 carbsG: carbsG,
+                sugarG: sugarG,
+                fiberG: fiberG,
                 fatG: fatG,
               ),
           withReferenceMapper: (p0) => p0
@@ -3102,6 +4342,8 @@ class $AppDatabaseManager {
       $$GoalsTableTableManager(_db, _db.goals);
   $$WeightEntriesTableTableManager get weightEntries =>
       $$WeightEntriesTableTableManager(_db, _db.weightEntries);
+  $$CustomFoodsTableTableManager get customFoods =>
+      $$CustomFoodsTableTableManager(_db, _db.customFoods);
   $$FoodLogEntriesTableTableManager get foodLogEntries =>
       $$FoodLogEntriesTableTableManager(_db, _db.foodLogEntries);
 }

--- a/lib/data/caltrack_repository.dart
+++ b/lib/data/caltrack_repository.dart
@@ -5,7 +5,7 @@ import 'package:caltrack/data/app_database.dart';
 import 'package:drift/drift.dart';
 
 export 'package:caltrack/data/app_database.dart'
-    show Profile, Goal, WeightEntry, FoodLogEntry;
+    show Profile, Goal, WeightEntry, FoodLogEntry, CustomFood;
 
 /// Aggregated intake for a calendar day (sums logged portions).
 class DailyIntakeTotals {
@@ -13,30 +13,45 @@ class DailyIntakeTotals {
     required this.kcal,
     required this.proteinG,
     required this.carbsG,
+    required this.sugarG,
+    required this.fiberG,
     required this.fatG,
   });
 
   final double kcal;
   final double proteinG;
   final double carbsG;
+  final double sugarG;
+  final double fiberG;
   final double fatG;
 
   static DailyIntakeTotals fromEntries(Iterable<FoodLogEntry> rows) {
     var k = 0.0;
     var p = 0.0;
     var c = 0.0;
+    var s = 0.0;
+    var fi = 0.0;
     var f = 0.0;
     for (final e in rows) {
       k += e.kcal;
       p += e.proteinG;
       c += e.carbsG;
+      s += e.sugarG;
+      fi += e.fiberG;
       f += e.fatG;
     }
-    return DailyIntakeTotals(kcal: k, proteinG: p, carbsG: c, fatG: f);
+    return DailyIntakeTotals(
+      kcal: k,
+      proteinG: p,
+      carbsG: c,
+      sugarG: s,
+      fiberG: fi,
+      fatG: f,
+    );
   }
 
   static const zero =
-      DailyIntakeTotals(kcal: 0, proteinG: 0, carbsG: 0, fatG: 0);
+      DailyIntakeTotals(kcal: 0, proteinG: 0, carbsG: 0, sugarG: 0, fiberG: 0, fatG: 0);
 }
 
 class ComputedPlan {
@@ -55,6 +70,15 @@ class CalTrackRepository {
   CalTrackRepository(this._db);
 
   final AppDatabase _db;
+
+  static String? normalizeBarcode(String raw) {
+    final digits = raw.replaceAll(RegExp(r'\D'), '');
+    if (digits.isEmpty) return null;
+    if (digits.length == 13) return digits;
+    if (digits.length == 12) return digits.padLeft(13, '0');
+    // Keep other lengths (e.g. UPC-E) as-is if user saved it.
+    return digits;
+  }
 
   Future<Profile> requireProfile() async {
     final rows = await _db.select(_db.profiles).get();
@@ -379,6 +403,8 @@ class CalTrackRepository {
     required double kcal,
     required double proteinG,
     required double carbsG,
+    double? sugarG,
+    double? fiberG,
     required double fatG,
   }) async {
     await (_db.update(_db.foodLogEntries)..where((t) => t.id.equals(id))).write(
@@ -387,6 +413,8 @@ class CalTrackRepository {
         kcal: Value(kcal),
         proteinG: Value(proteinG),
         carbsG: Value(carbsG),
+        sugarG: sugarG == null ? const Value.absent() : Value(sugarG),
+        fiberG: fiberG == null ? const Value.absent() : Value(fiberG),
         fatG: Value(fatG),
       ),
     );
@@ -395,11 +423,14 @@ class CalTrackRepository {
   Future<int> addFoodLogReturnId({
     required String source,
     String? catalogFoodId,
+    int? customFoodId,
     required String displayName,
     required double grams,
     required double kcal,
     required double proteinG,
     required double carbsG,
+    double sugarG = 0,
+    double fiberG = 0,
     required double fatG,
     DateTime? loggedAt,
   }) {
@@ -408,11 +439,14 @@ class CalTrackRepository {
             loggedAt: loggedAt ?? DateTime.now(),
             source: source,
             catalogFoodId: Value(catalogFoodId),
+            customFoodId: Value(customFoodId),
             displayName: displayName,
             grams: grams,
             kcal: kcal,
             proteinG: proteinG,
             carbsG: carbsG,
+            sugarG: Value(sugarG),
+            fiberG: Value(fiberG),
             fatG: fatG,
           ),
         );
@@ -421,11 +455,14 @@ class CalTrackRepository {
   Future<void> addFoodLog({
     required String source,
     String? catalogFoodId,
+    int? customFoodId,
     required String displayName,
     required double grams,
     required double kcal,
     required double proteinG,
     required double carbsG,
+    double sugarG = 0,
+    double fiberG = 0,
     required double fatG,
     DateTime? loggedAt,
   }) async {
@@ -434,11 +471,14 @@ class CalTrackRepository {
             loggedAt: loggedAt ?? DateTime.now(),
             source: source,
             catalogFoodId: Value(catalogFoodId),
+            customFoodId: Value(customFoodId),
             displayName: displayName,
             grams: grams,
             kcal: kcal,
             proteinG: proteinG,
             carbsG: carbsG,
+            sugarG: Value(sugarG),
+            fiberG: Value(fiberG),
             fatG: fatG,
           ),
         );
@@ -452,7 +492,7 @@ class CalTrackRepository {
     final seen = <String>{};
     final out = <FoodLogEntry>[];
     for (final r in rows) {
-      final key = r.catalogFoodId ?? r.displayName;
+      final key = r.catalogFoodId ?? (r.customFoodId?.toString() ?? r.displayName);
       if (seen.contains(key)) continue;
       seen.add(key);
       out.add(r);
@@ -461,8 +501,76 @@ class CalTrackRepository {
     return out;
   }
 
+  // ---- Custom foods ----
+
+  Future<CustomFood?> customFoodById(int id) {
+    return (_db.select(_db.customFoods)..where((t) => t.id.equals(id)))
+        .getSingleOrNull();
+  }
+
+  Future<CustomFood?> customFoodByBarcode(String rawBarcode) async {
+    final b = normalizeBarcode(rawBarcode);
+    if (b == null) return null;
+    return (_db.select(_db.customFoods)..where((t) => t.barcode.equals(b)))
+        .getSingleOrNull();
+  }
+
+  Future<List<CustomFood>> searchCustomFoods(String query, {int limit = 30}) async {
+    final q = query.trim();
+    if (q.isEmpty) return [];
+
+    final like = '%${q.replaceAll('%', r'\%').replaceAll('_', r'\_')}%';
+    final rows = await (_db.select(_db.customFoods)
+          ..where((t) => t.name.like(like) | t.brand.like(like))
+          ..orderBy([(t) => OrderingTerm.asc(t.name)])
+          ..limit(limit))
+        .get();
+    return rows;
+  }
+
+  Future<int> upsertCustomFood({
+    int? id,
+    required String name,
+    String? brand,
+    String? barcode,
+    required double servingSize,
+    required String servingUnit, // 'g' | 'ml'
+    required double calories,
+    required double fatG,
+    required double carbsG,
+    required double sugarG,
+    required double fiberG,
+    required double proteinG,
+  }) async {
+    final cleanedName = name.trim();
+    if (cleanedName.isEmpty) {
+      throw ArgumentError.value(name, 'name', 'must not be empty');
+    }
+    final b = barcode == null ? null : normalizeBarcode(barcode);
+    final companion = CustomFoodsCompanion(
+      id: id == null ? const Value.absent() : Value(id),
+      name: Value(cleanedName),
+      brand: Value(brand?.trim().isEmpty ?? true ? null : brand!.trim()),
+      barcode: Value(b),
+      servingSize: Value(servingSize),
+      servingUnit: Value(servingUnit),
+      calories: Value(calories),
+      fatG: Value(fatG),
+      carbsG: Value(carbsG),
+      sugarG: Value(sugarG),
+      fiberG: Value(fiberG),
+      proteinG: Value(proteinG),
+    );
+    return _db.into(_db.customFoods).insertOnConflictUpdate(companion);
+  }
+
+  Future<void> deleteCustomFood(int id) async {
+    await (_db.delete(_db.customFoods)..where((t) => t.id.equals(id))).go();
+  }
+
   Future<void> resetForTesting() async {
     await _db.delete(_db.foodLogEntries).go();
+    await _db.delete(_db.customFoods).go();
     await _db.delete(_db.weightEntries).go();
     await _db.delete(_db.goals).go();
     await (_db.update(_db.profiles)..where((t) => t.id.equals(1))).write(

--- a/lib/features/dashboard/home_screen.dart
+++ b/lib/features/dashboard/home_screen.dart
@@ -494,7 +494,10 @@ class _FoodLogTile extends StatelessWidget {
     double kcal100 = entry.grams > 0 ? entry.kcal * 100 / entry.grams : 0;
     double p100 = entry.grams > 0 ? entry.proteinG * 100 / entry.grams : 0;
     double c100 = entry.grams > 0 ? entry.carbsG * 100 / entry.grams : 0;
+    double s100 = entry.grams > 0 ? entry.sugarG * 100 / entry.grams : 0;
+    double fi100 = entry.grams > 0 ? entry.fiberG * 100 / entry.grams : 0;
     double f100 = entry.grams > 0 ? entry.fatG * 100 / entry.grams : 0;
+    var unitLabel = 'g';
 
     final id = entry.catalogFoodId;
     if (id != null) {
@@ -508,6 +511,22 @@ class _FoodLogTile extends StatelessWidget {
       }
     }
 
+    final customId = entry.customFoodId;
+    if (customId != null) {
+      final custom = await repo.customFoodById(customId);
+      if (custom != null) {
+        final serving = custom.servingSize;
+        final factor = serving > 0 ? 100.0 / serving : 1.0;
+        kcal100 = custom.calories * factor;
+        p100 = custom.proteinG * factor;
+        c100 = custom.carbsG * factor;
+        s100 = custom.sugarG * factor;
+        fi100 = custom.fiberG * factor;
+        f100 = custom.fatG * factor;
+        unitLabel = custom.servingUnit;
+      }
+    }
+
     if (!context.mounted) return;
     await showFoodEntrySheet(
       context,
@@ -515,13 +534,17 @@ class _FoodLogTile extends StatelessWidget {
         displayName: entry.displayName,
         source: entry.source,
         catalogFoodId: entry.catalogFoodId,
+        customFoodId: entry.customFoodId,
         kcalPer100g: kcal100,
         proteinPer100g: p100,
         carbsPer100g: c100,
+        sugarPer100g: s100,
+        fiberPer100g: fi100,
         fatPer100g: f100,
         initialGrams: entry.grams,
         editingEntryId: entry.id,
         loggedAtForEdit: entry.loggedAt,
+        unitLabel: unitLabel,
       ),
     );
   }
@@ -556,11 +579,14 @@ class _FoodLogTile extends StatelessWidget {
                 repo.addFoodLogReturnId(
                   source: entry.source,
                   catalogFoodId: entry.catalogFoodId,
+                  customFoodId: entry.customFoodId,
                   displayName: entry.displayName,
                   grams: entry.grams,
                   kcal: entry.kcal,
                   proteinG: entry.proteinG,
                   carbsG: entry.carbsG,
+                  sugarG: entry.sugarG,
+                  fiberG: entry.fiberG,
                   fatG: entry.fatG,
                   loggedAt: entry.loggedAt,
                 );

--- a/lib/features/food/add_custom_food_screen.dart
+++ b/lib/features/food/add_custom_food_screen.dart
@@ -1,0 +1,346 @@
+import 'package:caltrack/data/caltrack_repository.dart';
+import 'package:caltrack/data/app_database.dart';
+import 'package:caltrack/features/food/food_entry_sheet.dart';
+import 'package:caltrack/features/food/nutrition_label_scan_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:go_router/go_router.dart';
+import 'package:provider/provider.dart';
+
+class AddCustomFoodScreen extends StatefulWidget {
+  const AddCustomFoodScreen({super.key, this.initialBarcode});
+
+  final String? initialBarcode;
+
+  @override
+  State<AddCustomFoodScreen> createState() => _AddCustomFoodScreenState();
+}
+
+class _AddCustomFoodScreenState extends State<AddCustomFoodScreen> {
+  final _formKey = GlobalKey<FormState>();
+
+  late final TextEditingController _name = TextEditingController();
+  late final TextEditingController _brand = TextEditingController();
+  late final TextEditingController _barcode =
+      TextEditingController(text: widget.initialBarcode ?? '');
+
+  late final TextEditingController _servingSize = TextEditingController(text: '100');
+  ServingUnit _unit = ServingUnit.g;
+
+  late final TextEditingController _calories = TextEditingController();
+  late final TextEditingController _fat = TextEditingController();
+  late final TextEditingController _carbs = TextEditingController();
+  late final TextEditingController _sugar = TextEditingController();
+  late final TextEditingController _fiber = TextEditingController();
+  late final TextEditingController _protein = TextEditingController();
+
+  bool _busy = false;
+  int? _savedId;
+
+  @override
+  void dispose() {
+    _name.dispose();
+    _brand.dispose();
+    _barcode.dispose();
+    _servingSize.dispose();
+    _calories.dispose();
+    _fat.dispose();
+    _carbs.dispose();
+    _sugar.dispose();
+    _fiber.dispose();
+    _protein.dispose();
+    super.dispose();
+  }
+
+  static double? _parseNum(String raw, {bool allowZero = true}) {
+    final v = double.tryParse(raw.trim().replaceAll(',', '.'));
+    if (v == null) return null;
+    if (!allowZero && v <= 0) return null;
+    if (v < 0) return null;
+    return v;
+  }
+
+  Future<int?> _saveCustomFood() async {
+    if (!_formKey.currentState!.validate()) return null;
+    final repo = context.read<CalTrackRepository>();
+
+    final serving = _parseNum(_servingSize.text, allowZero: false)!;
+    final calories = _parseNum(_calories.text)!;
+    final fat = _parseNum(_fat.text)!;
+    final carbs = _parseNum(_carbs.text)!;
+    final sugar = _parseNum(_sugar.text)!;
+    final fiber = _parseNum(_fiber.text)!;
+    final protein = _parseNum(_protein.text)!;
+
+    setState(() => _busy = true);
+    try {
+      final id = await repo.upsertCustomFood(
+        id: _savedId,
+        name: _name.text,
+        brand: _brand.text.trim().isEmpty ? null : _brand.text,
+        barcode: _barcode.text.trim().isEmpty ? null : _barcode.text,
+        servingSize: serving,
+        servingUnit: _unit.name,
+        calories: calories,
+        fatG: fat,
+        carbsG: carbs,
+        sugarG: sugar,
+        fiberG: fiber,
+        proteinG: protein,
+      );
+      _savedId = id;
+      return id;
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  (double kcal100, double p100, double c100, double s100, double fi100, double f100)
+      _toPer100({
+    required double servingSize,
+    required double calories,
+    required double protein,
+    required double carbs,
+    required double sugar,
+    required double fiber,
+    required double fat,
+  }) {
+    final denom = servingSize <= 0 ? 1.0 : servingSize;
+    final factor = 100.0 / denom;
+    return (
+      calories * factor,
+      protein * factor,
+      carbs * factor,
+      sugar * factor,
+      fiber * factor,
+      fat * factor,
+    );
+  }
+
+  Future<void> _saveAndLog() async {
+    final id = await _saveCustomFood();
+    if (!mounted || id == null) return;
+
+    final serving = _parseNum(_servingSize.text, allowZero: false)!;
+    final calories = _parseNum(_calories.text)!;
+    final fat = _parseNum(_fat.text)!;
+    final carbs = _parseNum(_carbs.text)!;
+    final sugar = _parseNum(_sugar.text)!;
+    final fiber = _parseNum(_fiber.text)!;
+    final protein = _parseNum(_protein.text)!;
+
+    final (k100, p100, c100, s100, fi100, f100) = _toPer100(
+      servingSize: serving,
+      calories: calories,
+      protein: protein,
+      carbs: carbs,
+      sugar: sugar,
+      fiber: fiber,
+      fat: fat,
+    );
+
+    final action = await showFoodEntrySheet(
+      context,
+      FoodEntrySheetConfig(
+        displayName: _name.text.trim(),
+        source: 'custom',
+        customFoodId: id,
+        kcalPer100g: k100,
+        proteinPer100g: p100,
+        carbsPer100g: c100,
+        sugarPer100g: s100,
+        fiberPer100g: fi100,
+        fatPer100g: f100,
+        initialGrams: serving,
+        subtitle: 'Per $serving ${_unit.name}',
+        unitLabel: _unit.name,
+      ),
+    );
+    if (!mounted) return;
+    if (action == FoodEntryAction.added) {
+      if (context.canPop()) context.pop();
+    }
+  }
+
+  Future<void> _scanLabel() async {
+    final draft = await context.push<NutritionFactsDraft>('/scan-nutrition-label');
+    if (!mounted || draft == null) return;
+    if (draft.servingSize != null) {
+      _servingSize.text = draft.servingSize!.toString();
+    }
+    if (draft.servingUnit != null) {
+      _unit = draft.servingUnit!;
+    }
+    if (draft.calories != null) _calories.text = draft.calories!.toString();
+    if (draft.fatG != null) _fat.text = draft.fatG!.toString();
+    if (draft.carbsG != null) _carbs.text = draft.carbsG!.toString();
+    if (draft.sugarG != null) _sugar.text = draft.sugarG!.toString();
+    if (draft.fiberG != null) _fiber.text = draft.fiberG!.toString();
+    if (draft.proteinG != null) _protein.text = draft.proteinG!.toString();
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Add food')),
+      body: SafeArea(
+        child: Form(
+          key: _formKey,
+          child: ListView(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+            children: [
+              TextFormField(
+                controller: _name,
+                textInputAction: TextInputAction.next,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  labelText: 'Food name',
+                ),
+                validator: (v) =>
+                    v == null || v.trim().isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _brand,
+                textInputAction: TextInputAction.next,
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  labelText: 'Brand (optional)',
+                ),
+              ),
+              const SizedBox(height: 12),
+              TextFormField(
+                controller: _barcode,
+                keyboardType: TextInputType.number,
+                inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                decoration: const InputDecoration(
+                  border: OutlineInputBorder(),
+                  labelText: 'Barcode (optional)',
+                ),
+              ),
+              const SizedBox(height: 16),
+              Text('Serving', style: theme.textTheme.titleSmall),
+              const SizedBox(height: 8),
+              Row(
+                children: [
+                  Expanded(
+                    child: TextFormField(
+                      controller: _servingSize,
+                      keyboardType:
+                          const TextInputType.numberWithOptions(decimal: true),
+                      inputFormatters: [
+                        FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
+                      ],
+                      decoration: const InputDecoration(
+                        border: OutlineInputBorder(),
+                        labelText: 'Serving size',
+                      ),
+                      validator: (v) {
+                        final parsed = v == null ? null : _parseNum(v, allowZero: false);
+                        if (parsed == null) return 'Enter a number';
+                        if (parsed <= 0) return 'Must be > 0';
+                        return null;
+                      },
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  SegmentedButton<ServingUnit>(
+                    segments: const [
+                      ButtonSegment(value: ServingUnit.g, label: Text('g')),
+                      ButtonSegment(value: ServingUnit.ml, label: Text('ml')),
+                    ],
+                    selected: {_unit},
+                    onSelectionChanged: (s) {
+                      setState(() => _unit = s.first);
+                    },
+                  ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              Text('Nutrition per serving', style: theme.textTheme.titleSmall),
+              const SizedBox(height: 8),
+              _numField(_calories, label: 'Calories', suffix: 'kcal'),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(child: _numField(_fat, label: 'Total fat', suffix: 'g')),
+                  const SizedBox(width: 12),
+                  Expanded(child: _numField(_protein, label: 'Protein', suffix: 'g')),
+                ],
+              ),
+              const SizedBox(height: 12),
+              Row(
+                children: [
+                  Expanded(child: _numField(_carbs, label: 'Total carbs', suffix: 'g')),
+                  const SizedBox(width: 12),
+                  Expanded(child: _numField(_sugar, label: 'Sugar', suffix: 'g')),
+                ],
+              ),
+              const SizedBox(height: 12),
+              _numField(_fiber, label: 'Fiber', suffix: 'g'),
+              const SizedBox(height: 16),
+              OutlinedButton.icon(
+                onPressed: _busy ? null : _scanLabel,
+                icon: const Icon(Icons.document_scanner_outlined),
+                label: const Text('Take nutrition label picture'),
+              ),
+              const SizedBox(height: 20),
+              Row(
+                children: [
+                  Expanded(
+                    child: OutlinedButton(
+                      onPressed: _busy
+                          ? null
+                          : () async {
+                              final id = await _saveCustomFood();
+                              if (id == null) return;
+                              if (!context.mounted) return;
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(content: Text('Saved.')),
+                              );
+                            },
+                      child: const Text('Save'),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: FilledButton(
+                      onPressed: _busy ? null : _saveAndLog,
+                      child: const Text('Save & log'),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _numField(
+    TextEditingController c, {
+    required String label,
+    String? suffix,
+  }) {
+    return TextFormField(
+      controller: c,
+      keyboardType: const TextInputType.numberWithOptions(decimal: true),
+      inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]'))],
+      decoration: InputDecoration(
+        border: const OutlineInputBorder(),
+        labelText: label,
+        suffixText: suffix,
+      ),
+      validator: (v) {
+        final parsed = v == null ? null : _parseNum(v);
+        if (parsed == null) return 'Enter a number';
+        return null;
+      },
+    );
+  }
+}
+

--- a/lib/features/food/barcode_scan_screen.dart
+++ b/lib/features/food/barcode_scan_screen.dart
@@ -1,10 +1,13 @@
+import 'package:caltrack/data/caltrack_repository.dart';
 import 'package:caltrack/data/opennutrition_catalog.dart';
 import 'package:caltrack/widgets/opennutrition_attribution.dart';
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
 import 'package:provider/provider.dart';
 
-/// Scans barcodes and returns a single [CatalogFood] via [Navigator.pop], or nothing.
+/// Scans barcodes and returns either a [CatalogFood] or a [CustomFood] via
+/// [Navigator.pop], or redirects to the add-food form if not found.
 class BarcodeScanScreen extends StatefulWidget {
   const BarcodeScanScreen({super.key});
 
@@ -28,25 +31,33 @@ class _BarcodeScanScreenState extends State<BarcodeScanScreen> {
   Future<void> _onBarcode(String? raw) async {
     if (_handled || raw == null || raw.isEmpty) return;
     final catalog = context.read<OpenNutritionCatalog>();
+    final repo = context.read<CalTrackRepository>();
     final normalized = OpenNutritionCatalog.normalizeEan(raw);
     if (normalized == null) return;
 
     setState(() => _handled = true);
     await _controller.stop();
+
+    final custom = await repo.customFoodByBarcode(normalized);
+    if (!mounted) return;
+    if (custom != null) {
+      Navigator.of(context).pop(custom);
+      return;
+    }
+
     final foods = await catalog.byEan(normalized);
     if (!mounted) return;
 
     if (foods.isEmpty) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('No match in offline catalog for this barcode.')),
+      context.pushReplacement(
+        '/add-custom-food',
+        extra: {'barcode': normalized},
       );
-      setState(() => _handled = false);
-      await _controller.start();
       return;
     }
 
     if (foods.length == 1) {
-      Navigator.of(context).pop<CatalogFood>(foods.first);
+      Navigator.of(context).pop(foods.first);
       return;
     }
 
@@ -93,7 +104,7 @@ class _BarcodeScanScreenState extends State<BarcodeScanScreen> {
 
     if (!mounted) return;
     if (picked != null) {
-      Navigator.of(context).pop<CatalogFood>(picked);
+      Navigator.of(context).pop(picked);
     } else {
       setState(() => _handled = false);
       await _controller.start();

--- a/lib/features/food/food_entry_sheet.dart
+++ b/lib/features/food/food_entry_sheet.dart
@@ -13,23 +13,30 @@ class FoodEntrySheetConfig {
     required this.displayName,
     required this.source,
     this.catalogFoodId,
+    this.customFoodId,
     required this.kcalPer100g,
     required this.proteinPer100g,
     required this.carbsPer100g,
+    this.sugarPer100g = 0,
+    this.fiberPer100g = 0,
     required this.fatPer100g,
     this.initialGrams = 100,
     this.editingEntryId,
     this.loggedAtForEdit,
     this.subtitle,
+    this.unitLabel = 'g',
     this.showOpenNutritionAttribution = false,
   });
 
   final String displayName;
   final String source;
   final String? catalogFoodId;
+  final int? customFoodId;
   final double kcalPer100g;
   final double proteinPer100g;
   final double carbsPer100g;
+  final double sugarPer100g;
+  final double fiberPer100g;
   final double fatPer100g;
   final double initialGrams;
 
@@ -38,6 +45,7 @@ class FoodEntrySheetConfig {
   final DateTime? loggedAtForEdit;
 
   final String? subtitle;
+  final String unitLabel;
   final bool showOpenNutritionAttribution;
 
   bool get isEdit => editingEntryId != null;
@@ -101,6 +109,9 @@ class _FoodEntrySheetState extends State<_FoodEntrySheet> {
     final grams = _parseGrams();
     if (grams == null) return;
     final scaled = _scale(grams);
+    final factor = grams / 100.0;
+    final sugar = widget.config.sugarPer100g * factor;
+    final fiber = widget.config.fiberPer100g * factor;
     final repo = context.read<CalTrackRepository>();
     setState(() => _busy = true);
     try {
@@ -111,6 +122,8 @@ class _FoodEntrySheetState extends State<_FoodEntrySheet> {
           kcal: scaled.kcal,
           proteinG: scaled.proteinG,
           carbsG: scaled.carbsG,
+          sugarG: sugar,
+          fiberG: fiber,
           fatG: scaled.fatG,
         );
         if (!mounted) return;
@@ -119,11 +132,14 @@ class _FoodEntrySheetState extends State<_FoodEntrySheet> {
         await repo.addFoodLogReturnId(
           source: widget.config.source,
           catalogFoodId: widget.config.catalogFoodId,
+          customFoodId: widget.config.customFoodId,
           displayName: widget.config.displayName,
           grams: grams,
           kcal: scaled.kcal,
           proteinG: scaled.proteinG,
           carbsG: scaled.carbsG,
+          sugarG: sugar,
+          fiberG: fiber,
           fatG: scaled.fatG,
           loggedAt: widget.config.loggedAtForEdit,
         );
@@ -203,10 +219,10 @@ class _FoodEntrySheetState extends State<_FoodEntrySheet> {
               inputFormatters: [
                 FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
               ],
-              decoration: const InputDecoration(
+              decoration: InputDecoration(
                 border: OutlineInputBorder(),
                 labelText: 'Amount',
-                suffixText: 'g',
+                suffixText: cfg.unitLabel,
               ),
               onChanged: (_) => setState(() {}),
               onSubmitted: (_) => FocusScope.of(context).unfocus(),

--- a/lib/features/food/log_food_screen.dart
+++ b/lib/features/food/log_food_screen.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:caltrack/data/app_database.dart';
 import 'package:caltrack/data/caltrack_repository.dart';
 import 'package:caltrack/data/opennutrition_catalog.dart';
 import 'package:caltrack/features/food/food_entry_sheet.dart';
@@ -19,6 +20,7 @@ class _LogFoodScreenState extends State<LogFoodScreen> {
   final TextEditingController _search = TextEditingController();
   Timer? _debounce;
   List<CatalogFood> _results = [];
+  List<CustomFood> _customResults = [];
   bool _searching = false;
   String _lastQuery = '';
 
@@ -31,16 +33,53 @@ class _LogFoodScreenState extends State<LogFoodScreen> {
 
   Future<void> _runSearch(String q) async {
     final catalog = context.read<OpenNutritionCatalog>();
+    final repo = context.read<CalTrackRepository>();
     setState(() {
       _searching = true;
       _lastQuery = q;
     });
     try {
-      final list = await catalog.search(q);
+      final res = await Future.wait([
+        catalog.search(q),
+        repo.searchCustomFoods(q),
+      ]);
       if (!mounted || _lastQuery != q) return;
-      setState(() => _results = list);
+      setState(() {
+        _results = res[0] as List<CatalogFood>;
+        _customResults = res[1] as List<CustomFood>;
+      });
     } finally {
       if (mounted) setState(() => _searching = false);
+    }
+  }
+
+  Future<void> _openCustomFood(CustomFood food, {double? initialAmount}) async {
+    final serving = food.servingSize;
+    final factor = serving > 0 ? 100.0 / serving : 1.0;
+    final unit = ServingUnit.values.byName(food.servingUnit);
+
+    final action = await showFoodEntrySheet(
+      context,
+      FoodEntrySheetConfig(
+        displayName: food.name,
+        source: 'custom',
+        customFoodId: food.id,
+        kcalPer100g: food.calories * factor,
+        proteinPer100g: food.proteinG * factor,
+        carbsPer100g: food.carbsG * factor,
+        sugarPer100g: food.sugarG * factor,
+        fiberPer100g: food.fiberG * factor,
+        fatPer100g: food.fatG * factor,
+        initialGrams: initialAmount ?? serving,
+        subtitle: food.brand,
+        unitLabel: unit.name,
+      ),
+    );
+    if (!mounted || action == null) return;
+    if (action == FoodEntryAction.added) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Logged ${food.name}')),
+      );
     }
   }
 
@@ -72,12 +111,22 @@ class _LogFoodScreenState extends State<LogFoodScreen> {
 
   Future<void> _openRecentEntry(FoodLogEntry entry) async {
     final catalog = context.read<OpenNutritionCatalog>();
+    final repo = context.read<CalTrackRepository>();
     final id = entry.catalogFoodId;
     if (id != null) {
       final food = await catalog.byId(id);
       if (!mounted) return;
       if (food != null) {
         await _openCatalogFood(food, initialGrams: entry.grams);
+        return;
+      }
+    }
+    final customId = entry.customFoodId;
+    if (customId != null) {
+      final custom = await repo.customFoodById(customId);
+      if (!mounted) return;
+      if (custom != null) {
+        await _openCustomFood(custom, initialAmount: entry.grams);
         return;
       }
     }
@@ -91,6 +140,8 @@ class _LogFoodScreenState extends State<LogFoodScreen> {
         kcalPer100g: entry.kcal * per100Factor,
         proteinPer100g: entry.proteinG * per100Factor,
         carbsPer100g: entry.carbsG * per100Factor,
+        sugarPer100g: entry.sugarG * per100Factor,
+        fiberPer100g: entry.fiberG * per100Factor,
         fatPer100g: entry.fatG * per100Factor,
         initialGrams: entry.grams,
       ),
@@ -113,9 +164,12 @@ class _LogFoodScreenState extends State<LogFoodScreen> {
             tooltip: 'Scan barcode',
             icon: const Icon(Icons.qr_code_scanner_outlined),
             onPressed: () async {
-              final food = await context.push<CatalogFood>('/scan-barcode');
-              if (food != null && mounted) {
-                await _openCatalogFood(food);
+              final result = await context.push<Object?>('/scan-barcode');
+              if (!mounted || result == null) return;
+              if (result is CatalogFood) {
+                await _openCatalogFood(result);
+              } else if (result is CustomFood) {
+                await _openCustomFood(result);
               }
             },
           ),
@@ -138,7 +192,10 @@ class _LogFoodScreenState extends State<LogFoodScreen> {
                 _debounce?.cancel();
                 final q = text.trim();
                 if (q.length < 2) {
-                  setState(() => _results = []);
+                  setState(() {
+                    _results = [];
+                    _customResults = [];
+                  });
                   return;
                 }
                 _debounce = Timer(const Duration(milliseconds: 280), () {
@@ -199,6 +256,39 @@ class _LogFoodScreenState extends State<LogFoodScreen> {
                 Padding(
                   padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
                   child: Text(
+                    'Custom foods',
+                    style: Theme.of(context).textTheme.titleSmall,
+                  ),
+                ),
+                if (_customResults.isEmpty &&
+                    _search.text.trim().length >= 2 &&
+                    !_searching)
+                  const Padding(
+                    padding: EdgeInsets.symmetric(horizontal: 24),
+                    child: Text('No custom matches.'),
+                  ),
+                ..._customResults.map(
+                  (f) => ListTile(
+                    title: Text(f.name),
+                    subtitle: Text(
+                      [
+                        if (f.brand != null && f.brand!.isNotEmpty) f.brand!,
+                        '${f.calories.round()} kcal / ${f.servingSize.round()} ${f.servingUnit}',
+                      ].join(' · '),
+                    ),
+                    onTap: () => _openCustomFood(f),
+                  ),
+                ),
+                ListTile(
+                  leading: const Icon(Icons.add),
+                  title: const Text('Add a custom food'),
+                  subtitle: const Text('Create a food not in the offline catalog'),
+                  onTap: () => context.push('/add-custom-food'),
+                ),
+                const Divider(height: 32),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                  child: Text(
                     'Catalog results',
                     style: Theme.of(context).textTheme.titleSmall,
                   ),
@@ -208,7 +298,7 @@ class _LogFoodScreenState extends State<LogFoodScreen> {
                     !_searching)
                   const Padding(
                     padding: EdgeInsets.symmetric(horizontal: 24),
-                    child: Text('No matches.'),
+                    child: Text('No catalog matches.'),
                   ),
                 ..._results.map(
                   (f) => ListTile(

--- a/lib/features/food/nutrition_label_scan_screen.dart
+++ b/lib/features/food/nutrition_label_scan_screen.dart
@@ -1,0 +1,410 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:caltrack/core/nutrition_label_parser.dart';
+import 'package:caltrack/data/app_database.dart';
+import 'package:camera/camera.dart';
+import 'package:flutter/material.dart';
+import 'package:google_mlkit_text_recognition/google_mlkit_text_recognition.dart';
+
+/// Draft values extracted from a nutrition label.
+///
+/// Returned from `NutritionLabelScanScreen` back to the add-food form.
+class NutritionFactsDraft {
+  const NutritionFactsDraft({
+    this.servingSize,
+    this.servingUnit,
+    this.calories,
+    this.fatG,
+    this.carbsG,
+    this.sugarG,
+    this.fiberG,
+    this.proteinG,
+  });
+
+  final double? servingSize;
+  final ServingUnit? servingUnit;
+  final double? calories;
+  final double? fatG;
+  final double? carbsG;
+  final double? sugarG;
+  final double? fiberG;
+  final double? proteinG;
+}
+
+/// Nutrition label scan flow (OCR + highlight animation).
+class NutritionLabelScanScreen extends StatefulWidget {
+  const NutritionLabelScanScreen({super.key});
+
+  @override
+  State<NutritionLabelScanScreen> createState() => _NutritionLabelScanScreenState();
+}
+
+class _NutritionLabelScanScreenState extends State<NutritionLabelScanScreen>
+    with SingleTickerProviderStateMixin {
+  CameraController? _camera;
+  bool _initializing = true;
+  bool _capturing = false;
+
+  Uint8List? _imageBytes;
+  ui.Size? _imageSize;
+  NutritionParseResult? _parse;
+
+  late final AnimationController _anim = AnimationController(
+    vsync: this,
+    duration: const Duration(milliseconds: 1700),
+  );
+
+  @override
+  void initState() {
+    super.initState();
+    _initCamera();
+  }
+
+  @override
+  void dispose() {
+    _anim.dispose();
+    _camera?.dispose();
+    super.dispose();
+  }
+
+  Future<void> _initCamera() async {
+    try {
+      final cams = await availableCameras();
+      final back = cams.firstWhere(
+        (c) => c.lensDirection == CameraLensDirection.back,
+        orElse: () => cams.first,
+      );
+      final ctl = CameraController(
+        back,
+        ResolutionPreset.high,
+        enableAudio: false,
+        imageFormatGroup: ImageFormatGroup.jpeg,
+      );
+      await ctl.initialize();
+      if (!mounted) return;
+      setState(() {
+        _camera = ctl;
+        _initializing = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() => _initializing = false);
+    }
+  }
+
+  Future<void> _captureAndRecognize() async {
+    final cam = _camera;
+    if (cam == null || !cam.value.isInitialized || _capturing) return;
+    setState(() => _capturing = true);
+    try {
+      final file = await cam.takePicture();
+      final bytes = await File(file.path).readAsBytes();
+      final decoded = await _decodeImageSize(bytes);
+
+      final recognizer = TextRecognizer(script: TextRecognitionScript.latin);
+      try {
+        final input = InputImage.fromFilePath(file.path);
+        final recognized = await recognizer.processImage(input);
+        final parsed = parseNutritionLabel(recognized);
+        if (!mounted) return;
+        setState(() {
+          _imageBytes = bytes;
+          _imageSize = decoded;
+          _parse = parsed;
+        });
+        _anim
+          ..reset()
+          ..forward();
+      } finally {
+        recognizer.close();
+      }
+    } finally {
+      if (mounted) setState(() => _capturing = false);
+    }
+  }
+
+  static Future<ui.Size?> _decodeImageSize(Uint8List bytes) async {
+    final c = Completer<ui.Size?>();
+    try {
+      ui.decodeImageFromList(bytes, (img) {
+        if (c.isCompleted) return;
+        c.complete(ui.Size(img.width.toDouble(), img.height.toDouble()));
+      });
+    } catch (_) {
+      if (!c.isCompleted) c.complete(null);
+    }
+    return c.future;
+  }
+
+  void _finish() {
+    final p = _parse;
+    if (p == null) return;
+    Navigator.of(context).pop(
+      NutritionFactsDraft(
+        servingSize: p.draft.servingSize,
+        servingUnit: p.draft.servingUnit,
+        calories: p.draft.calories,
+        fatG: p.draft.fatG,
+        carbsG: p.draft.carbsG,
+        sugarG: p.draft.sugarG,
+        fiberG: p.draft.fiberG,
+        proteinG: p.draft.proteinG,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final cam = _camera;
+    final imgBytes = _imageBytes;
+    final imgSize = _imageSize;
+    final parse = _parse;
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Scan nutrition label'),
+        actions: [
+          if (parse != null)
+            TextButton(
+              onPressed: _finish,
+              child: const Text('Use'),
+            ),
+        ],
+      ),
+      body: _initializing
+          ? const Center(child: CircularProgressIndicator())
+          : (imgBytes == null || imgSize == null)
+              ? _CameraCaptureView(
+                  cam: cam,
+                  capturing: _capturing,
+                  onCapture: _captureAndRecognize,
+                )
+              : _ReviewView(
+                  bytes: imgBytes,
+                  imageSize: imgSize,
+                  parse: parse,
+                  animation: _anim,
+                  onRetake: () {
+                    setState(() {
+                      _imageBytes = null;
+                      _imageSize = null;
+                      _parse = null;
+                    });
+                  },
+                  onUse: _finish,
+                  capturing: _capturing,
+                  theme: theme,
+                ),
+    );
+  }
+}
+
+class _CameraCaptureView extends StatelessWidget {
+  const _CameraCaptureView({
+    required this.cam,
+    required this.capturing,
+    required this.onCapture,
+  });
+
+  final CameraController? cam;
+  final bool capturing;
+  final VoidCallback onCapture;
+
+  @override
+  Widget build(BuildContext context) {
+    if (cam == null || !cam!.value.isInitialized) {
+      return const Center(child: Text('Camera unavailable.'));
+    }
+    return SafeArea(
+      child: Column(
+        children: [
+          Expanded(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(16),
+              child: CameraPreview(cam!),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 24),
+            child: FilledButton.icon(
+              onPressed: capturing ? null : onCapture,
+              icon: capturing
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.camera_alt_outlined),
+              label: Text(capturing ? 'Processing…' : 'Capture'),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ReviewView extends StatelessWidget {
+  const _ReviewView({
+    required this.bytes,
+    required this.imageSize,
+    required this.parse,
+    required this.animation,
+    required this.onRetake,
+    required this.onUse,
+    required this.capturing,
+    required this.theme,
+  });
+
+  final Uint8List bytes;
+  final ui.Size imageSize;
+  final NutritionParseResult? parse;
+  final Animation<double> animation;
+  final VoidCallback onRetake;
+  final VoidCallback onUse;
+  final bool capturing;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    final fields = parse?.fields.values.toList() ?? const [];
+    return SafeArea(
+      child: Column(
+        children: [
+          Expanded(
+            child: LayoutBuilder(
+              builder: (context, c) {
+                final maxW = c.maxWidth;
+                final maxH = c.maxHeight;
+                final fit = _fitSize(imageSize, ui.Size(maxW, maxH));
+
+                return Center(
+                  child: SizedBox(
+                    width: fit.width,
+                    height: fit.height,
+                    child: Stack(
+                      fit: StackFit.expand,
+                      children: [
+                        Image.memory(bytes, fit: BoxFit.contain),
+                        IgnorePointer(
+                          child: AnimatedBuilder(
+                            animation: animation,
+                            builder: (context, _) {
+                              return CustomPaint(
+                                painter: _HighlightPainter(
+                                  fields: fields,
+                                  t: animation.value,
+                                  imageSize: imageSize,
+                                  displaySize: ui.Size(fit.width, fit.height),
+                                  color: theme.colorScheme.primary,
+                                ),
+                              );
+                            },
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+            child: Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: capturing ? null : onRetake,
+                    child: const Text('Retake'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: FilledButton(
+                    onPressed: parse == null ? null : onUse,
+                    child: const Text('Use values'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  static ui.Size _fitSize(ui.Size input, ui.Size bounds) {
+    if (input.width <= 0 || input.height <= 0) return bounds;
+    final inRatio = input.width / input.height;
+    final bRatio = bounds.width / bounds.height;
+    if (inRatio > bRatio) {
+      final w = bounds.width;
+      return ui.Size(w, w / inRatio);
+    } else {
+      final h = bounds.height;
+      return ui.Size(h * inRatio, h);
+    }
+  }
+}
+
+class _HighlightPainter extends CustomPainter {
+  _HighlightPainter({
+    required this.fields,
+    required this.t,
+    required this.imageSize,
+    required this.displaySize,
+    required this.color,
+  });
+
+  final List<ExtractedField<double>> fields;
+  final double t;
+  final ui.Size imageSize;
+  final ui.Size displaySize;
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, ui.Size size) {
+    if (fields.isEmpty) return;
+    final n = fields.length;
+    final idx = (t * n).clamp(0.0, n - 0.0001).floor();
+    final localT = (t * n) - idx;
+
+    final box = fields[idx].box;
+    final scaleX = displaySize.width / imageSize.width;
+    final scaleY = displaySize.height / imageSize.height;
+    final r = Rect.fromLTRB(
+      box.left * scaleX,
+      box.top * scaleY,
+      box.right * scaleX,
+      box.bottom * scaleY,
+    );
+
+    final eased = Curves.easeOut.transform(localT.clamp(0.0, 1.0));
+    final paintFill = Paint()
+      ..color = color.withValues(alpha: 0.18 * eased)
+      ..style = PaintingStyle.fill;
+    final paintStroke = Paint()
+      ..color = color.withValues(alpha: 0.95)
+      ..strokeWidth = 2
+      ..style = PaintingStyle.stroke;
+
+    final rr = RRect.fromRectAndRadius(r.inflate(6 * eased), const Radius.circular(10));
+    canvas.drawRRect(rr, paintFill);
+    canvas.drawRRect(rr, paintStroke);
+  }
+
+  @override
+  bool shouldRepaint(covariant _HighlightPainter oldDelegate) {
+    return oldDelegate.t != t ||
+        oldDelegate.fields != fields ||
+        oldDelegate.imageSize != imageSize ||
+        oldDelegate.displaySize != displaySize ||
+        oldDelegate.color != color;
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,8 @@ dependencies:
   sqlite3: ^2.5.0
   mobile_scanner: ^6.0.2
   url_launcher: ^6.3.1
+  camera: ^0.12.0+1
+  google_mlkit_text_recognition: ^0.15.1
 
 dev_dependencies:
   flutter_test:

--- a/test/nutrition_label_parser_test.dart
+++ b/test/nutrition_label_parser_test.dart
@@ -1,0 +1,137 @@
+import 'dart:ui';
+
+import 'package:caltrack/core/nutrition_label_parser.dart';
+import 'package:caltrack/data/app_database.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Rect r(double x, double y) => Rect.fromLTWH(x, y, 10, 10);
+
+void main() {
+  test('parseNutritionLabelFromLines extracts core fields', () {
+    final res = parseNutritionLabelFromLines([
+      OcrLine(text: 'Serving size 55 g', box: r(0, 0)),
+      OcrLine(text: 'Calories 230', box: r(0, 10)),
+      OcrLine(text: 'Total Fat 8g', box: r(0, 20)),
+      OcrLine(text: 'Total Carbohydrate 37g', box: r(0, 30)),
+      OcrLine(text: 'Total Sugars 12g', box: r(0, 40)),
+      OcrLine(text: 'Dietary Fiber 4g', box: r(0, 50)),
+      OcrLine(text: 'Protein 6g', box: r(0, 60)),
+    ]);
+
+    expect(res.draft.servingSize, 55);
+    expect(res.draft.servingUnit, ServingUnit.g);
+    expect(res.draft.calories, 230);
+    expect(res.draft.fatG, 8);
+    expect(res.draft.carbsG, 37);
+    expect(res.draft.sugarG, 12);
+    expect(res.draft.fiberG, 4);
+    expect(res.draft.proteinG, 6);
+    expect(res.fields, contains(NutritionField.calories));
+    expect(res.fields[NutritionField.protein]!.box, r(0, 60));
+  });
+
+  test('parseNutritionLabelFromLines handles comma decimals', () {
+    final res = parseNutritionLabelFromLines([
+      OcrLine(text: 'Serving size 250 ml', box: r(0, 0)),
+      OcrLine(text: 'Total Fat 3,5 g', box: r(0, 10)),
+    ]);
+    expect(res.draft.servingSize, 250);
+    expect(res.draft.servingUnit, ServingUnit.ml);
+    expect(res.draft.fatG, closeTo(3.5, 0.0001));
+  });
+
+  test('Canadian English cereal label: "Per 1 cup (30 g)"', () {
+    final res = parseNutritionLabelFromLines([
+      OcrLine(text: 'Nutrition Facts', box: r(0, 0)),
+      OcrLine(text: 'Per 1 cup (30 g)', box: r(0, 10)),
+      OcrLine(text: 'Calories 120', box: r(0, 20)),
+      OcrLine(text: 'Fat 1.5 g 2 %', box: r(0, 30)),
+      OcrLine(text: 'Carbohydrate 25 g 8 %', box: r(0, 40)),
+      OcrLine(text: 'Fibre 3 g 11 %', box: r(0, 50)),
+      OcrLine(text: 'Sugars 6 g', box: r(0, 60)),
+      OcrLine(text: 'Protein 3 g', box: r(0, 70)),
+    ]);
+
+    expect(res.draft.servingSize, 30);
+    expect(res.draft.servingUnit, ServingUnit.g);
+    expect(res.draft.calories, 120);
+    expect(res.draft.fatG, closeTo(1.5, 0.0001));
+    expect(res.draft.carbsG, 25);
+    expect(res.draft.fiberG, 3);
+    expect(res.draft.sugarG, 6);
+    expect(res.draft.proteinG, 3);
+  });
+
+  test('Canadian French cereal label: "pour 1 tasse (30 g)"', () {
+    final res = parseNutritionLabelFromLines([
+      OcrLine(text: 'Valeur nutritive', box: r(0, 0)),
+      OcrLine(text: 'pour 1 tasse (30 g)', box: r(0, 10)),
+      OcrLine(text: 'Calories 120', box: r(0, 20)),
+      OcrLine(text: 'Lipides 1,5 g 2 %', box: r(0, 30)),
+      OcrLine(text: 'Glucides 25 g 8 %', box: r(0, 40)),
+      OcrLine(text: 'Fibres 3 g 11 %', box: r(0, 50)),
+      OcrLine(text: 'Sucres 6 g', box: r(0, 60)),
+      OcrLine(text: 'Protéines 3 g', box: r(0, 70)),
+    ]);
+
+    expect(res.draft.servingSize, 30);
+    expect(res.draft.servingUnit, ServingUnit.g);
+    expect(res.draft.calories, 120);
+    expect(res.draft.fatG, closeTo(1.5, 0.0001));
+    expect(res.draft.carbsG, 25);
+    expect(res.draft.fiberG, 3);
+    expect(res.draft.sugarG, 6);
+    expect(res.draft.proteinG, 3);
+  });
+
+  test('Bilingual beverage label picks mL serving', () {
+    final res = parseNutritionLabelFromLines([
+      OcrLine(text: 'Per 250 mL / pour 250 ml', box: r(0, 0)),
+      OcrLine(text: 'Calories 110', box: r(0, 10)),
+      OcrLine(text: 'Fat / Lipides 0 g', box: r(0, 20)),
+    ]);
+
+    expect(res.draft.servingSize, 250);
+    expect(res.draft.servingUnit, ServingUnit.ml);
+    expect(res.draft.calories, 110);
+    expect(res.draft.fatG, 0);
+  });
+
+  test('Vertical layout: serving header on its own line', () {
+    final res = parseNutritionLabelFromLines([
+      OcrLine(text: 'Serving size', box: r(0, 0)),
+      OcrLine(text: '1 cup (30 g)', box: r(0, 10)),
+      OcrLine(text: 'Calories', box: r(0, 20)),
+      OcrLine(text: '230', box: r(0, 30)),
+    ]);
+
+    expect(res.draft.servingSize, 30);
+    expect(res.draft.servingUnit, ServingUnit.g);
+    expect(res.draft.calories, 230);
+  });
+
+  test('Macros ignore %DV and other companion numbers', () {
+    final res = parseNutritionLabelFromLines([
+      OcrLine(text: 'Serving size 100 g', box: r(0, 0)),
+      OcrLine(text: 'Total Fat 8 g 12 %', box: r(0, 10)),
+      OcrLine(text: 'Total Carbohydrate 37 g 13 %', box: r(0, 20)),
+      OcrLine(text: 'Protein 6 g 12 %', box: r(0, 30)),
+    ]);
+
+    expect(res.draft.fatG, 8);
+    expect(res.draft.carbsG, 37);
+    expect(res.draft.proteinG, 6);
+  });
+
+  test('Yogurt-style serving "Per 175 g (3/4 cup)"', () {
+    final res = parseNutritionLabelFromLines([
+      OcrLine(text: 'Per 175 g (3/4 cup)', box: r(0, 0)),
+      OcrLine(text: 'Calories 100', box: r(0, 10)),
+    ]);
+
+    expect(res.draft.servingSize, 175);
+    expect(res.draft.servingUnit, ServingUnit.g);
+    expect(res.draft.calories, 100);
+  });
+}
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Introduces a new local database table and schema migration for custom foods and adds new macro fields (`sugarG`, `fiberG`) to logged entries, which can impact existing persisted data. Also adds camera/OCR dependencies and new flows (barcode fallback + label scanning) that may be device-permission and parsing sensitive.
> 
> **Overview**
> Adds **custom food support** backed by a new `custom_foods` Drift table, plus links from `food_log_entries` via `customFoodId` and adds `sugarG`/`fiberG` columns with defaults; repository APIs and daily totals are updated accordingly.
> 
> Extends the food logging UI to **search, create, and log custom foods**, updates barcode scanning to return custom matches first and **redirect to an add-food form when not found**, and enhances the entry sheet to handle sugar/fiber and non-gram serving units.
> 
> Introduces a **nutrition label photo scan** flow using `camera` + ML Kit OCR with a new `nutrition_label_parser` (EN/FR heuristics + highlight review UI) and unit tests; Android Gradle config is adjusted to consistently target Java/Kotlin 17 across subprojects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fe387d17e7b4d90366e691868c0dbf7ef462930. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->