### PR TITLE
Feat/adding trends

### DIFF
--- a/Feature.md
+++ b/Feature.md
@@ -6,10 +6,15 @@
   - “Calorie bands” screen — One place that explains floor / maintenance / goal target with short copy (not medical advice) and how each is derived from inputs you already collect.
   - Sensitivity / “what-if” sliders — Let users nudge activity or weekly pace and see how maintenance vs goal calories move (no extra personal data).
 - User will not be presented with any personal info other than the necassary weight, height and activity level.
+- User should see how we calculate the TDEE during the onboarding.
+- User should see how we the app will adapt to their weekly reports (meaning that they understand the medothology of how and why would adjust their calory goal for their needs and best caloric floor/deficit/magnitude for them)
+- User should see a difference in impact when modifying their magnidute by having a visual/colour representation. 1kg a week could be read but much harder to sustain so may be not ideal for most, but .5kg a week may be slower but more effective in the long run.
+- use range of age and not a specific age selector, (e.g. 18-20, 20-25, 25-30... use the bigger number)
 
 ## Specific features
 
-- New item to track fiber and sugar.
-- Barcode “not found” fallback — open an add new food form which will be manually added. The user will be able to also add the macros via a nutritional bar scan from a picture.
+- New item to track fiber and sugar. (done)
+- Barcode “not found” fallback — open an add new food form which will be manually added. The user will be able to also add the macros via a nutritional bar scan from a picture. (done)
 - Trend windows — 7 / 14 / 30-day chart filters and simple stats (rate of change, consistency).
-- Weigh-in streaks / reminders — You already have notifications; surfacing adherence in UI helps motivation without new data.
+- Weigh-in streaks / reminders — You already have notifications; surfacing adherence in UI helps motivation without new data. (done)
+- create a script that will clean the OpenNutrition data by removing any branded items and only retaining whole foods like fruits, vegies, meats, grains and others. (done)

--- a/Feature.md
+++ b/Feature.md
@@ -15,6 +15,6 @@
 
 - New item to track fiber and sugar. (done)
 - Barcode “not found” fallback — open an add new food form which will be manually added. The user will be able to also add the macros via a nutritional bar scan from a picture. (done)
-- Trend windows — 7 / 14 / 30-day chart filters and simple stats (rate of change, consistency).
+- Trend windows — 7 / 14 / 30-day chart filters and simple stats (rate of change, consistency). (done)
 - Weigh-in streaks / reminders — You already have notifications; surfacing adherence in UI helps motivation without new data. (done)
-- create a script that will clean the OpenNutrition data by removing any branded items and only retaining whole foods like fruits, vegies, meats, grains and others. (done)
+- create a script that will clean the OpenNutrition data by removing any branded items and only retaining whole foods like fruits, vegies, meats, grains and others.

--- a/lib/app/router.dart
+++ b/lib/app/router.dart
@@ -34,7 +34,11 @@ GoRouter createRouter(ProfileController profileController) {
       ),
       GoRoute(
         path: '/log-weight',
-        builder: (context, state) => const LogWeightScreen(),
+        builder: (context, state) {
+          final raw = state.uri.queryParameters['id'];
+          final id = raw == null ? null : int.tryParse(raw);
+          return LogWeightScreen(editingEntryId: id);
+        },
       ),
       GoRoute(
         path: '/settings',
@@ -46,7 +50,11 @@ GoRouter createRouter(ProfileController profileController) {
       ),
       GoRoute(
         path: '/log-food',
-        builder: (context, state) => const LogFoodScreen(),
+        builder: (context, state) {
+          final dayParam = state.uri.queryParameters['day'];
+          final initialDay = _parseIsoDay(dayParam);
+          return LogFoodScreen(initialDay: initialDay);
+        },
       ),
       GoRoute(
         path: '/scan-barcode',
@@ -54,4 +62,17 @@ GoRouter createRouter(ProfileController profileController) {
       ),
     ],
   );
+}
+
+/// Parse a `YYYY-MM-DD` query value into a local-midnight DateTime.
+/// Returns null on malformed/missing input.
+DateTime? _parseIsoDay(String? raw) {
+  if (raw == null || raw.isEmpty) return null;
+  final m = RegExp(r'^(\d{4})-(\d{2})-(\d{2})$').firstMatch(raw);
+  if (m == null) return null;
+  final y = int.tryParse(m.group(1)!);
+  final mo = int.tryParse(m.group(2)!);
+  final d = int.tryParse(m.group(3)!);
+  if (y == null || mo == null || d == null) return null;
+  return DateTime(y, mo, d);
 }

--- a/lib/core/nutrition.dart
+++ b/lib/core/nutrition.dart
@@ -136,3 +136,144 @@ double? movingAverageWeightKg(List<double> weightsDescending, {int window = 7}) 
   }
   return total / slice.length;
 }
+
+/// Truncate a [DateTime] to the local calendar day (year-month-day, midnight).
+DateTime calendarDay(DateTime when) =>
+    DateTime(when.year, when.month, when.day);
+
+/// Stats over a trend window for weight tracking.
+class WeightTrendStats {
+  const WeightTrendStats({
+    required this.points,
+    required this.kgPerWeek,
+    required this.consistency,
+    required this.windowDays,
+    required this.distinctDaysLogged,
+  });
+
+  /// Filtered, chronologically-sorted entries inside the window.
+  final List<({DateTime recordedAt, double weightKg})> points;
+
+  /// Linear-fit rate of change in kg/week (null if not computable).
+  final double? kgPerWeek;
+
+  /// Fraction of days in the window with at least one weigh-in (0..1).
+  final double consistency;
+
+  final int windowDays;
+  final int distinctDaysLogged;
+
+  bool get hasEnoughData => points.length >= 2;
+}
+
+/// Compute trend stats for a weight series over the trailing [windowDays]
+/// ending at [referenceDay] (defaults to today).
+///
+/// Entries can be in any order. The result is sorted chronologically.
+/// Rate-of-change uses simple least-squares linear regression on
+/// (daysFromStart, weightKg) and is reported in **kg per week**.
+WeightTrendStats computeWeightTrendStats({
+  required Iterable<({DateTime recordedAt, double weightKg})> entries,
+  required int windowDays,
+  DateTime? referenceDay,
+}) {
+  assert(windowDays > 0);
+  final ref = calendarDay(referenceDay ?? DateTime.now());
+  final start = ref.subtract(Duration(days: windowDays - 1));
+  final inWindow = entries
+      .where((e) {
+        final d = calendarDay(e.recordedAt);
+        return !d.isBefore(start) && !d.isAfter(ref);
+      })
+      .toList()
+    ..sort((a, b) => a.recordedAt.compareTo(b.recordedAt));
+
+  final distinctDays = <DateTime>{
+    for (final e in inWindow) calendarDay(e.recordedAt),
+  };
+  final consistency = distinctDays.length / windowDays;
+
+  double? kgPerWeek;
+  if (inWindow.length >= 2) {
+    final first = inWindow.first.recordedAt;
+    final xs = <double>[];
+    final ys = <double>[];
+    for (final e in inWindow) {
+      final dx = e.recordedAt.difference(first).inMinutes / (60.0 * 24.0);
+      xs.add(dx);
+      ys.add(e.weightKg);
+    }
+    final n = xs.length;
+    final meanX = xs.reduce((a, b) => a + b) / n;
+    final meanY = ys.reduce((a, b) => a + b) / n;
+    var num = 0.0;
+    var den = 0.0;
+    for (var i = 0; i < n; i++) {
+      final dx = xs[i] - meanX;
+      num += dx * (ys[i] - meanY);
+      den += dx * dx;
+    }
+    if (den > 0) {
+      final slopePerDay = num / den;
+      kgPerWeek = slopePerDay * 7.0;
+    }
+  }
+
+  return WeightTrendStats(
+    points: inWindow,
+    kgPerWeek: kgPerWeek,
+    consistency: consistency.clamp(0.0, 1.0),
+    windowDays: windowDays,
+    distinctDaysLogged: distinctDays.length,
+  );
+}
+
+/// Result of a streak computation.
+class StreakInfo {
+  const StreakInfo({required this.current, required this.best});
+  final int current;
+  final int best;
+}
+
+/// Compute the current and best streaks of consecutive calendar days from
+/// a set of qualifying days.
+///
+/// "Current" is the run ending at [referenceDay] (or the previous day if
+/// [referenceDay] itself is not in the set, allowing today to count as
+/// "still on track" before logging). Pass [referenceDay] = the user's
+/// "today" in local time.
+StreakInfo computeDayStreak({
+  required Set<DateTime> qualifyingDays,
+  required DateTime referenceDay,
+}) {
+  final ref = calendarDay(referenceDay);
+  final norm = <DateTime>{
+    for (final d in qualifyingDays) calendarDay(d),
+  };
+
+  var current = 0;
+  var cursor = ref;
+  if (!norm.contains(cursor)) {
+    cursor = cursor.subtract(const Duration(days: 1));
+  }
+  while (norm.contains(cursor)) {
+    current++;
+    cursor = cursor.subtract(const Duration(days: 1));
+  }
+
+  if (norm.isEmpty) return const StreakInfo(current: 0, best: 0);
+  final sorted = norm.toList()..sort();
+  var best = 1;
+  var run = 1;
+  for (var i = 1; i < sorted.length; i++) {
+    final diff = sorted[i].difference(sorted[i - 1]).inDays;
+    if (diff == 1) {
+      run++;
+      if (run > best) best = run;
+    } else {
+      run = 1;
+    }
+  }
+  if (current > best) best = current;
+  return StreakInfo(current: current, best: best);
+}

--- a/lib/data/caltrack_repository.dart
+++ b/lib/data/caltrack_repository.dart
@@ -212,6 +212,48 @@ class CalTrackRepository {
     await checkGoalCompletionAfterWeighIn();
   }
 
+  /// Look up the most recent weight entry on the same calendar day as
+  /// [day] (local time). Returns null if the day has no entries.
+  Future<WeightEntry?> weightEntryForDay(DateTime day) async {
+    final (s, e) = _dayBounds(day);
+    final rows = await (_db.select(_db.weightEntries)
+          ..where((t) =>
+              t.recordedAt.isBiggerOrEqualValue(s) &
+              t.recordedAt.isSmallerThanValue(e))
+          ..orderBy([(t) => OrderingTerm.desc(t.recordedAt)])
+          ..limit(1))
+        .get();
+    return rows.isEmpty ? null : rows.first;
+  }
+
+  Future<WeightEntry?> weightEntryById(int id) async {
+    final rows = await (_db.select(_db.weightEntries)
+          ..where((t) => t.id.equals(id))
+          ..limit(1))
+        .get();
+    return rows.isEmpty ? null : rows.first;
+  }
+
+  Future<void> updateWeightEntry({
+    required int id,
+    required double weightKg,
+    String? note,
+  }) async {
+    await (_db.update(_db.weightEntries)..where((t) => t.id.equals(id))).write(
+      WeightEntriesCompanion(
+        weightKg: Value(weightKg),
+        note: Value(note),
+      ),
+    );
+    await recacheDailyTarget();
+    await checkGoalCompletionAfterWeighIn();
+  }
+
+  Future<void> deleteWeightEntry(int id) async {
+    await (_db.delete(_db.weightEntries)..where((t) => t.id.equals(id))).go();
+    await recacheDailyTarget();
+  }
+
   Future<void> updateMacroSplit({
     required int proteinPct,
     required int carbsPct,
@@ -346,6 +388,67 @@ class CalTrackRepository {
               t.loggedAt.isSmallerThanValue(e)))
         .get();
     return DailyIntakeTotals.fromEntries(rows);
+  }
+
+  /// Aggregate kcal logged per calendar day in [start, endExclusive).
+  /// Returned map keys are local-midnight DateTimes; days with no entries
+  /// are omitted (callers should treat missing keys as 0).
+  Future<Map<DateTime, double>> dailyKcalTotals({
+    required DateTime start,
+    required DateTime endExclusive,
+  }) async {
+    final s = DateTime(start.year, start.month, start.day);
+    final e = DateTime(
+      endExclusive.year,
+      endExclusive.month,
+      endExclusive.day,
+    );
+    final rows = await (_db.select(_db.foodLogEntries)
+          ..where((t) =>
+              t.loggedAt.isBiggerOrEqualValue(s) &
+              t.loggedAt.isSmallerThanValue(e)))
+        .get();
+    final out = <DateTime, double>{};
+    for (final r in rows) {
+      final d = DateTime(
+        r.loggedAt.year,
+        r.loggedAt.month,
+        r.loggedAt.day,
+      );
+      out.update(d, (v) => v + r.kcal, ifAbsent: () => r.kcal);
+    }
+    return out;
+  }
+
+  /// Reactive variant of [dailyKcalTotals] driven by changes to the food
+  /// log table.
+  Stream<Map<DateTime, double>> watchDailyKcalTotals({
+    required DateTime start,
+    required DateTime endExclusive,
+  }) {
+    final s = DateTime(start.year, start.month, start.day);
+    final e = DateTime(
+      endExclusive.year,
+      endExclusive.month,
+      endExclusive.day,
+    );
+    return (_db.select(_db.foodLogEntries)
+          ..where((t) =>
+              t.loggedAt.isBiggerOrEqualValue(s) &
+              t.loggedAt.isSmallerThanValue(e)))
+        .watch()
+        .map((rows) {
+      final out = <DateTime, double>{};
+      for (final r in rows) {
+        final d = DateTime(
+          r.loggedAt.year,
+          r.loggedAt.month,
+          r.loggedAt.day,
+        );
+        out.update(d, (v) => v + r.kcal, ifAbsent: () => r.kcal);
+      }
+      return out;
+    });
   }
 
   Stream<DailyIntakeTotals> watchIntakeForDay(DateTime day) {

--- a/lib/features/dashboard/home_screen.dart
+++ b/lib/features/dashboard/home_screen.dart
@@ -1,4 +1,5 @@
 import 'package:caltrack/app/profile_controller.dart';
+import 'package:caltrack/core/nutrition.dart';
 import 'package:caltrack/core/units.dart';
 import 'package:caltrack/data/caltrack_repository.dart';
 import 'package:caltrack/data/opennutrition_catalog.dart';
@@ -25,6 +26,29 @@ class DashboardTab extends StatefulWidget {
 
 class _DashboardTabState extends State<DashboardTab> {
   bool _celebrationHandled = false;
+  late DateTime _selectedDay = calendarDay(DateTime.now());
+
+  void _shiftDay(int days) {
+    setState(() {
+      _selectedDay = _selectedDay.add(Duration(days: days));
+    });
+  }
+
+  Future<void> _pickDay() async {
+    final today = calendarDay(DateTime.now());
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: _selectedDay,
+      firstDate: today.subtract(const Duration(days: 365 * 5)),
+      lastDate: today,
+    );
+    if (!mounted || picked == null) return;
+    setState(() => _selectedDay = calendarDay(picked));
+  }
+
+  void _resetToToday() {
+    setState(() => _selectedDay = calendarDay(DateTime.now()));
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -64,6 +88,11 @@ class _DashboardTabState extends State<DashboardTab> {
             profileCtl: profileCtl,
             goal: goal,
             bottomInset: widget.bottomInset,
+            selectedDay: _selectedDay,
+            onPrevDay: () => _shiftDay(-1),
+            onNextDay: () => _shiftDay(1),
+            onPickDay: _pickDay,
+            onResetToday: _resetToToday,
           ),
         );
       },
@@ -125,19 +154,42 @@ class _DashboardListView extends StatelessWidget {
     required this.profileCtl,
     required this.goal,
     required this.bottomInset,
+    required this.selectedDay,
+    required this.onPrevDay,
+    required this.onNextDay,
+    required this.onPickDay,
+    required this.onResetToday,
   });
 
   final CalTrackRepository repo;
   final ProfileController profileCtl;
   final Goal? goal;
   final double bottomInset;
+  final DateTime selectedDay;
+  final VoidCallback onPrevDay;
+  final VoidCallback onNextDay;
+  final VoidCallback onPickDay;
+  final VoidCallback onResetToday;
 
   @override
   Widget build(BuildContext context) {
     final currentGoal = goal;
+    final today = calendarDay(DateTime.now());
+    final isToday = selectedDay == today;
+    final canGoForward = selectedDay.isBefore(today);
+
     return ListView(
       padding: EdgeInsets.fromLTRB(20, 20, 20, 20 + bottomInset),
       children: [
+        _DayNavigator(
+          selectedDay: selectedDay,
+          isToday: isToday,
+          canGoForward: canGoForward,
+          onPrev: onPrevDay,
+          onNext: canGoForward ? onNextDay : null,
+          onPick: onPickDay,
+          onReset: isToday ? null : onResetToday,
+        ),
         const SizedBox(height: 16),
         FutureBuilder<ComputedPlan?>(
           future: repo.computePlanForProfile(profileCtl.profile!, currentGoal),
@@ -154,16 +206,27 @@ class _DashboardListView extends StatelessWidget {
               );
             }
             return StreamBuilder<DailyIntakeTotals>(
-              stream: repo.watchIntakeForDay(DateTime.now()),
+              stream: repo.watchIntakeForDay(selectedDay),
               builder: (context, intakeSnap) {
                 final intake = intakeSnap.data ?? DailyIntakeTotals.zero;
-                return _TodaySummaryCard(plan: plan, intake: intake);
+                return _TodaySummaryCard(
+                  plan: plan,
+                  intake: intake,
+                  selectedDay: selectedDay,
+                  isToday: isToday,
+                );
               },
             );
           },
         ),
         const SizedBox(height: 16),
-        _TodayFoodLogCard(repo: repo),
+        _FoodAdherenceStreakCard(
+          repo: repo,
+          dailyTarget: profileCtl.profile!.dailyCalorieTarget,
+          referenceDay: selectedDay,
+        ),
+        const SizedBox(height: 16),
+        _TodayFoodLogCard(repo: repo, selectedDay: selectedDay, isToday: isToday),
         const SizedBox(height: 16),
         if (currentGoal != null) _GoalSummary(goal: currentGoal),
         const SizedBox(height: 16),
@@ -210,10 +273,17 @@ class _DashboardListView extends StatelessWidget {
 /// One unified card showing today's intake against the daily plan:
 /// calories (consumed / target) plus per-macro progress bars.
 class _TodaySummaryCard extends StatelessWidget {
-  const _TodaySummaryCard({required this.plan, required this.intake});
+  const _TodaySummaryCard({
+    required this.plan,
+    required this.intake,
+    required this.selectedDay,
+    required this.isToday,
+  });
 
   final ComputedPlan plan;
   final DailyIntakeTotals intake;
+  final DateTime selectedDay;
+  final bool isToday;
 
   @override
   Widget build(BuildContext context) {
@@ -243,7 +313,12 @@ class _TodaySummaryCard extends StatelessWidget {
               textBaseline: TextBaseline.alphabetic,
               children: [
                 Expanded(
-                  child: Text('Today', style: theme.textTheme.titleMedium),
+                  child: Text(
+                    isToday
+                        ? 'Today'
+                        : DateFormat.MMMEd().format(selectedDay),
+                    style: theme.textTheme.titleMedium,
+                  ),
                 ),
                 Text(
                   remainingLabel,
@@ -417,20 +492,39 @@ class _GoalSummary extends StatelessWidget {
   }
 }
 
-/// Lists every food log entry for the current calendar day, with
+/// Lists every food log entry for the selected calendar day, with
 /// swipe-to-delete and an undo SnackBar.
 class _TodayFoodLogCard extends StatelessWidget {
-  const _TodayFoodLogCard({required this.repo});
+  const _TodayFoodLogCard({
+    required this.repo,
+    required this.selectedDay,
+    required this.isToday,
+  });
 
   final CalTrackRepository repo;
+  final DateTime selectedDay;
+  final bool isToday;
+
+  String _formatDayParam(DateTime day) {
+    final y = day.year.toString().padLeft(4, '0');
+    final m = day.month.toString().padLeft(2, '0');
+    final d = day.day.toString().padLeft(2, '0');
+    return '$y-$m-$d';
+  }
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return StreamBuilder<List<FoodLogEntry>>(
-      stream: repo.watchFoodLogsForDay(DateTime.now()),
+      stream: repo.watchFoodLogsForDay(selectedDay),
       builder: (context, snap) {
         final entries = snap.data ?? const <FoodLogEntry>[];
+        final title = isToday
+            ? "Today's food"
+            : 'Food · ${DateFormat.MMMd().format(selectedDay)}';
+        final emptyMsg = isToday
+            ? 'Nothing logged yet today.'
+            : 'Nothing logged on this day.';
         return Card(
           clipBehavior: Clip.hardEdge,
           child: Column(
@@ -442,7 +536,7 @@ class _TodayFoodLogCard extends StatelessWidget {
                   children: [
                     Expanded(
                       child: Text(
-                        "Today's food",
+                        title,
                         style: theme.textTheme.titleMedium,
                       ),
                     ),
@@ -454,7 +548,12 @@ class _TodayFoodLogCard extends StatelessWidget {
                     ),
                     const SizedBox(width: 8),
                     TextButton.icon(
-                      onPressed: () => context.push('/log-food'),
+                      onPressed: () {
+                        final path = isToday
+                            ? '/log-food'
+                            : '/log-food?day=${_formatDayParam(selectedDay)}';
+                        context.push(path);
+                      },
                       icon: const Icon(Icons.add, size: 18),
                       label: const Text('Add'),
                     ),
@@ -465,7 +564,7 @@ class _TodayFoodLogCard extends StatelessWidget {
                 Padding(
                   padding: const EdgeInsets.fromLTRB(20, 0, 20, 20),
                   child: Text(
-                    'Nothing logged yet today.',
+                    emptyMsg,
                     style: theme.textTheme.bodyMedium?.copyWith(
                       color: theme.colorScheme.onSurfaceVariant,
                     ),
@@ -584,6 +683,157 @@ class _FoodLogTile extends StatelessWidget {
         ),
         onTap: () => _openEdit(context),
       ),
+    );
+  }
+}
+
+/// Compact day picker on top of the dashboard. Lets the user navigate to
+/// previous days to add or modify logs without leaving the home screen.
+class _DayNavigator extends StatelessWidget {
+  const _DayNavigator({
+    required this.selectedDay,
+    required this.isToday,
+    required this.canGoForward,
+    required this.onPrev,
+    required this.onNext,
+    required this.onPick,
+    required this.onReset,
+  });
+
+  final DateTime selectedDay;
+  final bool isToday;
+  final bool canGoForward;
+  final VoidCallback onPrev;
+  final VoidCallback? onNext;
+  final VoidCallback onPick;
+  final VoidCallback? onReset;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final today = calendarDay(DateTime.now());
+    final yesterday = today.subtract(const Duration(days: 1));
+
+    String label;
+    if (isToday) {
+      label = 'Today';
+    } else if (selectedDay == yesterday) {
+      label = 'Yesterday';
+    } else {
+      label = DateFormat.yMMMEd().format(selectedDay);
+    }
+
+    return Card(
+      elevation: 0,
+      color: scheme.surfaceContainerHighest.withValues(alpha: 0.45),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 4),
+        child: Row(
+          children: [
+            IconButton(
+              tooltip: 'Previous day',
+              onPressed: onPrev,
+              icon: const Icon(Icons.chevron_left),
+            ),
+            Expanded(
+              child: TextButton.icon(
+                onPressed: onPick,
+                icon: const Icon(Icons.calendar_today_outlined, size: 18),
+                label: Text(
+                  label,
+                  style: theme.textTheme.titleSmall,
+                ),
+              ),
+            ),
+            IconButton(
+              tooltip: 'Next day',
+              onPressed: canGoForward ? onNext : null,
+              icon: const Icon(Icons.chevron_right),
+            ),
+            if (onReset != null)
+              TextButton(
+                onPressed: onReset,
+                child: const Text('Today'),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Shows a compact food-logging adherence streak ("X days >= 80% of target")
+/// based on the cached daily calorie target. Hidden if the user has no
+/// daily target yet (e.g. before onboarding completes a plan).
+class _FoodAdherenceStreakCard extends StatelessWidget {
+  const _FoodAdherenceStreakCard({
+    required this.repo,
+    required this.dailyTarget,
+    required this.referenceDay,
+  });
+
+  final CalTrackRepository repo;
+  final double? dailyTarget;
+  final DateTime referenceDay;
+
+  static const _lookbackDays = 60;
+  static const _adherenceFraction = 0.8;
+
+  @override
+  Widget build(BuildContext context) {
+    final target = dailyTarget;
+    if (target == null || target <= 0) {
+      return const SizedBox.shrink();
+    }
+    final ref = calendarDay(referenceDay);
+    final start = ref.subtract(const Duration(days: _lookbackDays - 1));
+    final endExclusive = ref.add(const Duration(days: 1));
+
+    return StreamBuilder<Map<DateTime, double>>(
+      stream: repo.watchDailyKcalTotals(
+        start: start,
+        endExclusive: endExclusive,
+      ),
+      builder: (context, snap) {
+        final theme = Theme.of(context);
+        final scheme = theme.colorScheme;
+        final totals = snap.data ?? const <DateTime, double>{};
+        final qualifying = <DateTime>{
+          for (final entry in totals.entries)
+            if (entry.value >= target * _adherenceFraction) entry.key,
+        };
+        final streak = computeDayStreak(
+          qualifyingDays: qualifying,
+          referenceDay: ref,
+        );
+
+        final headline = streak.current > 0
+            ? 'Logging streak: ${streak.current} '
+                '${streak.current == 1 ? "day" : "days"}'
+            : 'No active logging streak';
+        final sub =
+            'Days where you logged at least ${(_adherenceFraction * 100).round()}% '
+            'of your calorie target.${streak.best > 0 ? " Best: ${streak.best}." : ""}';
+
+        return Card(
+          child: ListTile(
+            leading: Icon(
+              Icons.local_fire_department_outlined,
+              color: streak.current > 0
+                  ? scheme.primary
+                  : scheme.onSurfaceVariant,
+            ),
+            title: Text(headline),
+            subtitle: Text(
+              sub,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: scheme.onSurfaceVariant,
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 }

--- a/lib/features/food/log_food_screen.dart
+++ b/lib/features/food/log_food_screen.dart
@@ -6,10 +6,15 @@ import 'package:caltrack/features/food/food_entry_sheet.dart';
 import 'package:caltrack/widgets/opennutrition_attribution.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 
 class LogFoodScreen extends StatefulWidget {
-  const LogFoodScreen({super.key});
+  const LogFoodScreen({super.key, this.initialDay});
+
+  /// When non-null, new entries default to a timestamp on this day rather
+  /// than [DateTime.now()].
+  final DateTime? initialDay;
 
   @override
   State<LogFoodScreen> createState() => _LogFoodScreenState();
@@ -27,6 +32,29 @@ class _LogFoodScreenState extends State<LogFoodScreen> {
     _debounce?.cancel();
     _search.dispose();
     super.dispose();
+  }
+
+  /// Returns the timestamp to use for a new log entry. If we're targeting
+  /// a non-today day, snap to noon on that day so it deterministically
+  /// falls inside the day bounds and reads as a reasonable time.
+  DateTime? _initialLoggedAt() {
+    final day = widget.initialDay;
+    if (day == null) return null;
+    final today = DateTime.now();
+    final isToday = day.year == today.year &&
+        day.month == today.month &&
+        day.day == today.day;
+    if (isToday) return null;
+    return DateTime(day.year, day.month, day.day, 12);
+  }
+
+  bool get _isAlternateDay {
+    final day = widget.initialDay;
+    if (day == null) return false;
+    final today = DateTime.now();
+    return !(day.year == today.year &&
+        day.month == today.month &&
+        day.day == today.day);
   }
 
   Future<void> _runSearch(String q) async {
@@ -60,6 +88,7 @@ class _LogFoodScreenState extends State<LogFoodScreen> {
         fatPer100g: food.fatPer100g,
         initialGrams: initialGrams,
         showOpenNutritionAttribution: true,
+        loggedAtForEdit: _initialLoggedAt(),
       ),
     );
     if (!mounted || action == null) return;
@@ -93,6 +122,7 @@ class _LogFoodScreenState extends State<LogFoodScreen> {
         carbsPer100g: entry.carbsG * per100Factor,
         fatPer100g: entry.fatG * per100Factor,
         initialGrams: entry.grams,
+        loggedAtForEdit: _initialLoggedAt(),
       ),
     );
     if (!mounted || action != FoodEntryAction.added) return;
@@ -105,9 +135,14 @@ class _LogFoodScreenState extends State<LogFoodScreen> {
   Widget build(BuildContext context) {
     final repo = context.read<CalTrackRepository>();
 
+    final theme = Theme.of(context);
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Log food'),
+        title: Text(
+          _isAlternateDay && widget.initialDay != null
+              ? 'Log food · ${DateFormat.MMMd().format(widget.initialDay!)}'
+              : 'Log food',
+        ),
         actions: [
           IconButton(
             tooltip: 'Scan barcode',
@@ -124,6 +159,35 @@ class _LogFoodScreenState extends State<LogFoodScreen> {
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
+          if (_isAlternateDay && widget.initialDay != null)
+            Container(
+              width: double.infinity,
+              color: theme.colorScheme.tertiaryContainer
+                  .withValues(alpha: 0.5),
+              padding: const EdgeInsets.symmetric(
+                horizontal: 16,
+                vertical: 10,
+              ),
+              child: Row(
+                children: [
+                  Icon(
+                    Icons.event_note_outlined,
+                    size: 18,
+                    color: theme.colorScheme.onTertiaryContainer,
+                  ),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'Adding to '
+                      '${DateFormat.yMMMEd().format(widget.initialDay!)}',
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.onTertiaryContainer,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
           Padding(
             padding: const EdgeInsets.fromLTRB(16, 16, 16, 8),
             child: TextField(

--- a/lib/features/weight/log_weight_screen.dart
+++ b/lib/features/weight/log_weight_screen.dart
@@ -7,7 +7,11 @@ import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
 class LogWeightScreen extends StatefulWidget {
-  const LogWeightScreen({super.key});
+  const LogWeightScreen({super.key, this.editingEntryId});
+
+  /// When non-null, the screen prefills and updates the existing entry
+  /// rather than creating a new one.
+  final int? editingEntryId;
 
   @override
   State<LogWeightScreen> createState() => _LogWeightScreenState();
@@ -17,6 +21,17 @@ class _LogWeightScreenState extends State<LogWeightScreen> {
   final _controller = TextEditingController();
   final _noteController = TextEditingController();
 
+  bool _loading = true;
+  bool _saving = false;
+  WeightEntry? _editingEntry;
+  late WeightUnit _unit;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _bootstrap());
+  }
+
   @override
   void dispose() {
     _controller.dispose();
@@ -24,76 +39,204 @@ class _LogWeightScreenState extends State<LogWeightScreen> {
     super.dispose();
   }
 
+  Future<void> _bootstrap() async {
+    final repo = context.read<CalTrackRepository>();
+    final profile = await repo.requireProfile();
+    if (!mounted) return;
+    _unit = WeightUnit.fromStored(profile.weightUnit);
+
+    final id = widget.editingEntryId;
+    if (id != null) {
+      final existing = await repo.weightEntryById(id);
+      if (!mounted) return;
+      _editingEntry = existing;
+      if (existing != null) {
+        final shown = _unit == WeightUnit.kg
+            ? existing.weightKg
+            : kgToLb(existing.weightKg);
+        _controller.text = _formatWeight(shown);
+        _noteController.text = existing.note ?? '';
+      }
+    }
+    setState(() => _loading = false);
+  }
+
+  static String _formatWeight(double v) =>
+      v == v.roundToDouble() ? v.toStringAsFixed(1) : v.toStringAsFixed(1);
+
+  double? _parseWeightKg() {
+    final raw = _controller.text.trim().replaceAll(',', '.');
+    final v = double.tryParse(raw);
+    if (v == null || v <= 0) return null;
+    return _unit == WeightUnit.kg ? v : lbToKg(v);
+  }
+
+  String? _trimmedNote() {
+    final n = _noteController.text.trim();
+    return n.isEmpty ? null : n;
+  }
+
   Future<void> _submit() async {
     final repo = context.read<CalTrackRepository>();
     final profileCtl = context.read<ProfileController>();
-    final profile = await repo.requireProfile();
-    if (!mounted) return;
-    final unit = WeightUnit.fromStored(profile.weightUnit);
-    final raw = _controller.text.trim().replaceAll(',', '.');
-    final v = double.tryParse(raw);
-    if (v == null || v <= 0) {
+    final kg = _parseWeightKg();
+    if (kg == null) {
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Enter a valid weight.')),
       );
       return;
     }
-    final kg = unit == WeightUnit.kg ? v : lbToKg(v);
-    await repo.addWeightEntry(
-      weightKg: kg,
-      note: _noteController.text.trim().isEmpty ? null : _noteController.text.trim(),
+    final note = _trimmedNote();
+
+    setState(() => _saving = true);
+    try {
+      final editing = _editingEntry;
+      if (editing != null) {
+        await repo.updateWeightEntry(id: editing.id, weightKg: kg, note: note);
+      } else {
+        final today = await repo.weightEntryForDay(DateTime.now());
+        if (today != null) {
+          if (!mounted) return;
+          final replace = await _confirmReplaceTodaysEntry(today);
+          if (replace != true) {
+            return;
+          }
+          await repo.updateWeightEntry(
+            id: today.id,
+            weightKg: kg,
+            note: note,
+          );
+        } else {
+          await repo.addWeightEntry(weightKg: kg, note: note);
+        }
+      }
+      await profileCtl.refresh();
+      if (!mounted) return;
+      context.pop();
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
+  }
+
+  Future<bool?> _confirmReplaceTodaysEntry(WeightEntry today) {
+    final shown = _unit == WeightUnit.kg
+        ? today.weightKg
+        : kgToLb(today.weightKg);
+    final label = '${shown.toStringAsFixed(1)} ${_unit.shortLabel}';
+    return showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Update today\'s weigh-in?'),
+        content: Text(
+          'You already logged $label today. Do you want to change your '
+          'weigh-in for today?',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Update'),
+          ),
+        ],
+      ),
     );
-    await profileCtl.refresh();
-    if (!mounted) return;
-    context.pop();
+  }
+
+  Future<void> _delete() async {
+    final editing = _editingEntry;
+    if (editing == null) return;
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete weigh-in?'),
+        content: const Text('This entry will be permanently removed.'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(false),
+            child: const Text('Cancel'),
+          ),
+          FilledButton(
+            style: FilledButton.styleFrom(
+              backgroundColor: Theme.of(ctx).colorScheme.error,
+            ),
+            onPressed: () => Navigator.of(ctx).pop(true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirmed != true || !mounted) return;
+    final repo = context.read<CalTrackRepository>();
+    final profileCtl = context.read<ProfileController>();
+    setState(() => _saving = true);
+    try {
+      await repo.deleteWeightEntry(editing.id);
+      await profileCtl.refresh();
+      if (!mounted) return;
+      context.pop();
+    } finally {
+      if (mounted) setState(() => _saving = false);
+    }
   }
 
   @override
   Widget build(BuildContext context) {
-    final repo = context.read<CalTrackRepository>();
+    final isEdit = widget.editingEntryId != null;
     return Scaffold(
-      appBar: AppBar(title: const Text('Log weight')),
-      body: FutureBuilder(
-        future: repo.requireProfile(),
-        builder: (context, snap) {
-          if (!snap.hasData) {
-            return const Center(child: CircularProgressIndicator());
-          }
-          final unit = WeightUnit.fromStored(snap.data!.weightUnit);
-          final suffix = unit.shortLabel;
-          return Padding(
-            padding: const EdgeInsets.all(24),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                TextField(
-                  controller: _controller,
-                  autofocus: true,
-                  decoration: InputDecoration(
-                    labelText: 'Weight ($suffix)',
-                  ),
-                  keyboardType: const TextInputType.numberWithOptions(decimal: true),
-                  inputFormatters: [
-                    FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
-                  ],
-                ),
-                const SizedBox(height: 16),
-                TextField(
-                  controller: _noteController,
-                  decoration: const InputDecoration(
-                    labelText: 'Note (optional)',
-                  ),
-                  maxLines: 2,
-                ),
-                const Spacer(),
-                FilledButton(
-                  onPressed: _submit,
-                  child: const Text('Save'),
-                ),
-              ],
+      appBar: AppBar(
+        title: Text(isEdit ? 'Edit weigh-in' : 'Log weight'),
+        actions: [
+          if (isEdit)
+            IconButton(
+              tooltip: 'Delete',
+              onPressed: _saving || _loading ? null : _delete,
+              icon: const Icon(Icons.delete_outline),
             ),
-          );
-        },
+        ],
+      ),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : (isEdit && _editingEntry == null
+              ? const Center(child: Text('Entry not found.'))
+              : _buildForm(context)),
+    );
+  }
+
+  Widget _buildForm(BuildContext context) {
+    final suffix = _unit.shortLabel;
+    return Padding(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          TextField(
+            controller: _controller,
+            autofocus: true,
+            decoration: InputDecoration(
+              labelText: 'Weight ($suffix)',
+            ),
+            keyboardType: const TextInputType.numberWithOptions(decimal: true),
+            inputFormatters: [
+              FilteringTextInputFormatter.allow(RegExp(r'[0-9.,]')),
+            ],
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: _noteController,
+            decoration: const InputDecoration(
+              labelText: 'Note (optional)',
+            ),
+            maxLines: 2,
+          ),
+          const Spacer(),
+          FilledButton(
+            onPressed: _saving ? null : _submit,
+            child: Text(_editingEntry != null ? 'Save changes' : 'Save'),
+          ),
+        ],
       ),
     );
   }

--- a/lib/features/weight/weight_analytics_tab.dart
+++ b/lib/features/weight/weight_analytics_tab.dart
@@ -1,3 +1,4 @@
+import 'package:caltrack/core/nutrition.dart';
 import 'package:caltrack/core/units.dart';
 import 'package:caltrack/data/caltrack_repository.dart';
 import 'package:fl_chart/fl_chart.dart';
@@ -41,6 +42,13 @@ class WeightAnalyticsTab extends StatelessWidget {
               );
             }
 
+            final streak = computeDayStreak(
+              qualifyingDays: {
+                for (final e in entries) calendarDay(e.recordedAt),
+              },
+              referenceDay: DateTime.now(),
+            );
+
             return ListView(
               padding: EdgeInsets.fromLTRB(20, 20, 20, 20 + bottomInset),
               children: [
@@ -50,15 +58,10 @@ class WeightAnalyticsTab extends StatelessWidget {
                   goalTargetKg: goal?.targetWeightKg,
                   intendedWeeklyKg: goal?.weeklyChangeKgPerWeek,
                   unit: unit,
+                  streak: streak,
                 ),
                 const SizedBox(height: 16),
                 _TrendChartCard(entries: entries, unit: unit),
-                const SizedBox(height: 16),
-                FilledButton.tonalIcon(
-                  onPressed: () => context.push('/weekly-review'),
-                  icon: const Icon(Icons.insights_outlined),
-                  label: const Text('Weekly review'),
-                ),
                 const SizedBox(height: 16),
                 Text(
                   'Recent entries',
@@ -135,6 +138,7 @@ class _SummaryCard extends StatelessWidget {
     required this.goalTargetKg,
     required this.intendedWeeklyKg,
     required this.unit,
+    required this.streak,
   });
 
   final double latestKg;
@@ -142,6 +146,7 @@ class _SummaryCard extends StatelessWidget {
   final double? goalTargetKg;
   final double? intendedWeeklyKg;
   final WeightUnit unit;
+  final StreakInfo streak;
 
   String _fmt(double kg) {
     final v = unit == WeightUnit.kg ? kg : kgToLb(kg);
@@ -200,6 +205,28 @@ class _SummaryCard extends StatelessWidget {
             ),
             const SizedBox(height: 4),
             ?deltaWidget,
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Icon(
+                  Icons.local_fire_department_outlined,
+                  size: 18,
+                  color: streak.current > 0
+                      ? scheme.primary
+                      : scheme.onSurfaceVariant,
+                ),
+                const SizedBox(width: 6),
+                Text(
+                  streak.current > 0
+                      ? 'Weigh-in streak: ${streak.current} '
+                          '${streak.current == 1 ? "day" : "days"}'
+                          ' (best ${streak.best})'
+                      : 'No active weigh-in streak'
+                          '${streak.best > 0 ? " (best ${streak.best})" : ""}',
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ],
+            ),
             if (goalKg != null) ...[
               const Divider(height: 28),
               Row(
@@ -231,121 +258,286 @@ class _SummaryCard extends StatelessWidget {
   }
 }
 
-class _TrendChartCard extends StatelessWidget {
+class _TrendChartCard extends StatefulWidget {
   const _TrendChartCard({required this.entries, required this.unit});
 
   final List<WeightEntry> entries;
   final WeightUnit unit;
 
   @override
+  State<_TrendChartCard> createState() => _TrendChartCardState();
+}
+
+class _TrendChartCardState extends State<_TrendChartCard> {
+  static const _windows = <int>[7, 14, 30];
+  int _windowDays = 14;
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final chronological = [...entries]
-      ..sort((a, b) => a.recordedAt.compareTo(b.recordedAt));
+    final unit = widget.unit;
 
-    double display(double kg) =>
-        unit == WeightUnit.kg ? kg : kgToLb(kg);
+    final stats = computeWeightTrendStats(
+      entries: widget.entries.map(
+        (e) => (recordedAt: e.recordedAt, weightKg: e.weightKg),
+      ),
+      windowDays: _windowDays,
+    );
+    final filtered = stats.points;
+
+    double display(double kg) => unit == WeightUnit.kg ? kg : kgToLb(kg);
 
     final spots = <FlSpot>[];
-    for (var i = 0; i < chronological.length; i++) {
-      spots.add(FlSpot(i.toDouble(), display(chronological[i].weightKg)));
+    for (var i = 0; i < filtered.length; i++) {
+      spots.add(FlSpot(i.toDouble(), display(filtered[i].weightKg)));
     }
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(8, 16, 16, 12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(12, 0, 4, 8),
+              child: Row(
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Trend (${unit.shortLabel})',
+                      style: theme.textTheme.titleSmall,
+                    ),
+                  ),
+                  SegmentedButton<int>(
+                    style: const ButtonStyle(
+                      visualDensity: VisualDensity.compact,
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                    showSelectedIcon: false,
+                    segments: [
+                      for (final w in _windows)
+                        ButtonSegment<int>(
+                          value: w,
+                          label: Text('${w}d'),
+                        ),
+                    ],
+                    selected: {_windowDays},
+                    onSelectionChanged: (s) =>
+                        setState(() => _windowDays = s.first),
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(
+              height: 200,
+              child: spots.length < 2
+                  ? Center(
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: Text(
+                          'Log at least two weigh-ins in the last '
+                          '$_windowDays days to see the trend.',
+                          textAlign: TextAlign.center,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                      ),
+                    )
+                  : _buildChart(theme, spots, filtered, display),
+            ),
+            const SizedBox(height: 8),
+            _TrendStatsRow(stats: stats, unit: unit),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildChart(
+    ThemeData theme,
+    List<FlSpot> spots,
+    List<({DateTime recordedAt, double weightKg})> filtered,
+    double Function(double kg) display,
+  ) {
     final ys = spots.map((s) => s.y);
     final minY = ys.reduce((a, b) => a < b ? a : b);
     final maxY = ys.reduce((a, b) => a > b ? a : b);
     final pad = (maxY - minY).abs() < 0.5 ? 2.0 : (maxY - minY) * 0.1;
 
-    return Card(
-      child: Padding(
-        padding: const EdgeInsets.fromLTRB(8, 16, 16, 8),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Padding(
-              padding: const EdgeInsets.only(left: 12, bottom: 8),
-              child: Text(
-                'Trend (${unit.shortLabel})',
-                style: theme.textTheme.titleSmall,
+    return LineChart(
+      LineChartData(
+        minY: minY - pad,
+        maxY: maxY + pad,
+        gridData: FlGridData(
+          show: true,
+          drawVerticalLine: false,
+          horizontalInterval:
+              ((maxY - minY).abs() / 4).clamp(0.5, double.infinity),
+        ),
+        titlesData: FlTitlesData(
+          bottomTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 28,
+              getTitlesWidget: (value, meta) {
+                final i = value.round();
+                if (i < 0 || i >= filtered.length) {
+                  return const SizedBox.shrink();
+                }
+                final d = filtered[i].recordedAt;
+                return Padding(
+                  padding: const EdgeInsets.only(top: 6),
+                  child: Text(
+                    DateFormat.Md().format(d),
+                    style: theme.textTheme.bodySmall,
+                  ),
+                );
+              },
+            ),
+          ),
+          leftTitles: AxisTitles(
+            sideTitles: SideTitles(
+              showTitles: true,
+              reservedSize: 36,
+              getTitlesWidget: (value, meta) => Text(
+                value.toStringAsFixed(0),
+                style: theme.textTheme.bodySmall,
               ),
             ),
-            SizedBox(
-              height: 200,
-              child: LineChart(
-                LineChartData(
-                  minY: minY - pad,
-                  maxY: maxY + pad,
-                  gridData: FlGridData(
-                    show: true,
-                    drawVerticalLine: false,
-                    horizontalInterval: ((maxY - minY).abs() / 4)
-                        .clamp(0.5, double.infinity),
-                  ),
-                  titlesData: FlTitlesData(
-                    bottomTitles: AxisTitles(
-                      sideTitles: SideTitles(
-                        showTitles: true,
-                        reservedSize: 28,
-                        getTitlesWidget: (value, meta) {
-                          final i = value.round();
-                          if (i < 0 || i >= chronological.length) {
-                            return const SizedBox.shrink();
-                          }
-                          final d = chronological[i].recordedAt;
-                          return Padding(
-                            padding: const EdgeInsets.only(top: 6),
-                            child: Text(
-                              DateFormat.Md().format(d),
-                              style: theme.textTheme.bodySmall,
-                            ),
-                          );
-                        },
-                      ),
-                    ),
-                    leftTitles: AxisTitles(
-                      sideTitles: SideTitles(
-                        showTitles: true,
-                        reservedSize: 36,
-                        getTitlesWidget: (value, meta) => Text(
-                          value.toStringAsFixed(0),
-                          style: theme.textTheme.bodySmall,
-                        ),
-                      ),
-                    ),
-                    topTitles: const AxisTitles(
-                      sideTitles: SideTitles(showTitles: false),
-                    ),
-                    rightTitles: const AxisTitles(
-                      sideTitles: SideTitles(showTitles: false),
-                    ),
-                  ),
-                  borderData: FlBorderData(show: false),
-                  lineBarsData: [
-                    LineChartBarData(
-                      spots: spots,
-                      isCurved: true,
-                      color: theme.colorScheme.primary,
-                      barWidth: 3,
-                      dotData: FlDotData(
-                        show: spots.length <= 30,
-                        getDotPainter: (spot, _, _, _) => FlDotCirclePainter(
-                          radius: 3,
-                          color: theme.colorScheme.primary,
-                          strokeWidth: 0,
-                        ),
-                      ),
-                      belowBarData: BarAreaData(
-                        show: true,
-                        color: theme.colorScheme.primary
-                            .withValues(alpha: 0.15),
-                      ),
-                    ),
-                  ],
+          ),
+          topTitles: const AxisTitles(
+            sideTitles: SideTitles(showTitles: false),
+          ),
+          rightTitles: const AxisTitles(
+            sideTitles: SideTitles(showTitles: false),
+          ),
+        ),
+        borderData: FlBorderData(show: false),
+        lineBarsData: [
+          LineChartBarData(
+            spots: spots,
+            isCurved: true,
+            color: theme.colorScheme.primary,
+            barWidth: 3,
+            dotData: FlDotData(
+              show: spots.length <= 30,
+              getDotPainter: (spot, _, _, _) => FlDotCirclePainter(
+                radius: 3,
+                color: theme.colorScheme.primary,
+                strokeWidth: 0,
+              ),
+            ),
+            belowBarData: BarAreaData(
+              show: true,
+              color:
+                  theme.colorScheme.primary.withValues(alpha: 0.15),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TrendStatsRow extends StatelessWidget {
+  const _TrendStatsRow({required this.stats, required this.unit});
+
+  final WeightTrendStats stats;
+  final WeightUnit unit;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final scheme = theme.colorScheme;
+    final rate = stats.kgPerWeek;
+
+    String rateLabel;
+    if (rate == null) {
+      rateLabel = '\u2014';
+    } else {
+      final v = unit == WeightUnit.kg ? rate : kgToLb(rate);
+      final sign = v > 0 ? '+' : (v < 0 ? '' : '');
+      rateLabel = '$sign${v.toStringAsFixed(2)} ${unit.shortLabel}/wk';
+    }
+
+    final consistencyPct = (stats.consistency * 100).round();
+
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(12, 0, 4, 0),
+      child: Row(
+        children: [
+          Expanded(
+            child: _StatTile(
+              label: 'Rate',
+              value: rateLabel,
+              color: scheme.primary,
+              icon: rate == null
+                  ? Icons.show_chart
+                  : (rate > 0
+                      ? Icons.trending_up
+                      : (rate < 0
+                          ? Icons.trending_down
+                          : Icons.trending_flat)),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: _StatTile(
+              label: 'Consistency',
+              value:
+                  '$consistencyPct% (${stats.distinctDaysLogged}/${stats.windowDays}d)',
+              color: scheme.secondary,
+              icon: Icons.check_circle_outline,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _StatTile extends StatelessWidget {
+  const _StatTile({
+    required this.label,
+    required this.value,
+    required this.color,
+    required this.icon,
+  });
+
+  final String label;
+  final String value;
+  final Color color;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        Icon(icon, size: 18, color: color),
+        const SizedBox(width: 6),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                label,
+                style: theme.textTheme.labelSmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
                 ),
               ),
-            ),
-          ],
+              Text(
+                value,
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ],
+          ),
         ),
-      ),
+      ],
     );
   }
 }
@@ -375,12 +567,24 @@ class _EntriesList extends StatelessWidget {
               subtitle: Text(
                 DateFormat.yMMMd().add_jm().format(entries[i].recordedAt),
               ),
-              trailing: entries[i].note != null && entries[i].note!.isNotEmpty
-                  ? Icon(
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (entries[i].note != null &&
+                      entries[i].note!.isNotEmpty)
+                    Icon(
                       Icons.notes_outlined,
                       color: theme.colorScheme.outline,
-                    )
-                  : null,
+                    ),
+                  IconButton(
+                    tooltip: 'Edit',
+                    icon: const Icon(Icons.edit_outlined),
+                    onPressed: () =>
+                        context.push('/log-weight?id=${entries[i].id}'),
+                  ),
+                ],
+              ),
+              onTap: () => context.push('/log-weight?id=${entries[i].id}'),
             ),
             if (i < entries.length - 1) const Divider(height: 1),
           ],

--- a/test/caltrack_repository_test.dart
+++ b/test/caltrack_repository_test.dart
@@ -1,0 +1,211 @@
+import 'package:caltrack/data/app_database.dart';
+import 'package:caltrack/data/caltrack_repository.dart';
+import 'package:drift/drift.dart' hide isNotNull;
+import 'package:drift/native.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('CalTrackRepository (in-memory)', () {
+    late AppDatabase db;
+    late CalTrackRepository repo;
+
+    setUp(() async {
+      db = AppDatabase.forTesting(NativeDatabase.memory());
+      repo = CalTrackRepository(db);
+
+      // Minimal seeded profile so repo helpers that depend on it won't crash.
+      await db.into(db.profiles).insert(
+            ProfilesCompanion.insert(
+              sex: 'male',
+              birthDateMillis: DateTime(1996, 1, 1).millisecondsSinceEpoch,
+              heightCm: 175,
+              activityLevel: 2,
+              weightUnit: 'kg',
+              proteinPct: 30,
+              carbsPct: 40,
+              fatPct: 30,
+              reminderWeekday: DateTime.sunday,
+              reminderHour: 9,
+              reminderMinute: 0,
+              onboardingCompleted: const Value(true),
+              dailyCalorieTarget: const Value(2000),
+            ),
+          );
+    });
+
+    tearDown(() async {
+      await db.close();
+    });
+
+    test('watchFoodLogsForDay only returns entries in that calendar day', () async {
+      final day = DateTime(2026, 4, 28);
+      final start = DateTime(2026, 4, 28, 0, 0);
+      final endMinus1 = DateTime(2026, 4, 28, 23, 59);
+      final nextDay = DateTime(2026, 4, 29, 0, 1);
+
+      await repo.addFoodLog(
+        source: 'custom',
+        displayName: 'A',
+        grams: 100,
+        kcal: 100,
+        proteinG: 0,
+        carbsG: 0,
+        fatG: 0,
+        loggedAt: start,
+      );
+      await repo.addFoodLog(
+        source: 'custom',
+        displayName: 'B',
+        grams: 100,
+        kcal: 200,
+        proteinG: 0,
+        carbsG: 0,
+        fatG: 0,
+        loggedAt: endMinus1,
+      );
+      await repo.addFoodLog(
+        source: 'custom',
+        displayName: 'C',
+        grams: 100,
+        kcal: 300,
+        proteinG: 0,
+        carbsG: 0,
+        fatG: 0,
+        loggedAt: nextDay,
+      );
+
+      final results = await repo.watchFoodLogsForDay(day).first;
+      expect(results.map((e) => e.displayName).toList(), ['B', 'A']);
+    });
+
+    test('watchIntakeForDay sums kcal/macros within day bounds', () async {
+      final day = DateTime(2026, 4, 28);
+      await repo.addFoodLog(
+        source: 'custom',
+        displayName: 'A',
+        grams: 100,
+        kcal: 100,
+        proteinG: 10,
+        carbsG: 20,
+        fatG: 5,
+        loggedAt: DateTime(2026, 4, 28, 8, 0),
+      );
+      await repo.addFoodLog(
+        source: 'custom',
+        displayName: 'B',
+        grams: 100,
+        kcal: 250,
+        proteinG: 5,
+        carbsG: 10,
+        fatG: 10,
+        loggedAt: DateTime(2026, 4, 28, 20, 0),
+      );
+      await repo.addFoodLog(
+        source: 'custom',
+        displayName: 'NextDay',
+        grams: 100,
+        kcal: 999,
+        proteinG: 999,
+        carbsG: 999,
+        fatG: 999,
+        loggedAt: DateTime(2026, 4, 29, 0, 1),
+      );
+
+      final totals = await repo.watchIntakeForDay(day).first;
+      expect(totals.kcal, 350);
+      expect(totals.proteinG, 15);
+      expect(totals.carbsG, 30);
+      expect(totals.fatG, 15);
+    });
+
+    test('dailyKcalTotals aggregates by calendar day', () async {
+      await repo.addFoodLog(
+        source: 'custom',
+        displayName: 'D1-A',
+        grams: 100,
+        kcal: 100,
+        proteinG: 0,
+        carbsG: 0,
+        fatG: 0,
+        loggedAt: DateTime(2026, 4, 27, 10),
+      );
+      await repo.addFoodLog(
+        source: 'custom',
+        displayName: 'D1-B',
+        grams: 100,
+        kcal: 200,
+        proteinG: 0,
+        carbsG: 0,
+        fatG: 0,
+        loggedAt: DateTime(2026, 4, 27, 20),
+      );
+      await repo.addFoodLog(
+        source: 'custom',
+        displayName: 'D2',
+        grams: 100,
+        kcal: 50,
+        proteinG: 0,
+        carbsG: 0,
+        fatG: 0,
+        loggedAt: DateTime(2026, 4, 28, 9),
+      );
+
+      final totals = await repo.dailyKcalTotals(
+        start: DateTime(2026, 4, 27),
+        endExclusive: DateTime(2026, 4, 29),
+      );
+
+      expect(totals[DateTime(2026, 4, 27)], 300);
+      expect(totals[DateTime(2026, 4, 28)], 50);
+      expect(totals.containsKey(DateTime(2026, 4, 29)), isFalse);
+    });
+
+    test('weightEntryForDay returns latest entry within that day', () async {
+      final day = DateTime(2026, 4, 28);
+      await db.into(db.weightEntries).insert(
+            WeightEntriesCompanion.insert(
+              recordedAt: DateTime(2026, 4, 28, 8, 0),
+              weightKg: 80.0,
+              note: const Value('morning'),
+            ),
+          );
+      await db.into(db.weightEntries).insert(
+            WeightEntriesCompanion.insert(
+              recordedAt: DateTime(2026, 4, 28, 18, 0),
+              weightKg: 79.5,
+              note: const Value('evening'),
+            ),
+          );
+      await db.into(db.weightEntries).insert(
+            WeightEntriesCompanion.insert(
+              recordedAt: DateTime(2026, 4, 29, 8, 0),
+              weightKg: 79.0,
+              note: const Value('next'),
+            ),
+          );
+
+      final entry = await repo.weightEntryForDay(day);
+      expect(entry, isNotNull);
+      expect(entry!.weightKg, 79.5);
+      expect(entry.note, 'evening');
+    });
+
+    test('updateWeightEntry updates weight and note', () async {
+      final id = await db.into(db.weightEntries).insert(
+            WeightEntriesCompanion.insert(
+              recordedAt: DateTime(2026, 4, 28, 8, 0),
+              weightKg: 80.0,
+              note: const Value('before'),
+            ),
+          );
+
+      await repo.updateWeightEntry(id: id, weightKg: 79.8, note: 'after');
+      final updated = await repo.weightEntryById(id);
+
+      expect(updated, isNotNull);
+      expect(updated!.weightKg, 79.8);
+      expect(updated.note, 'after');
+    });
+  });
+}
+

--- a/test/nutrition_test.dart
+++ b/test/nutrition_test.dart
@@ -67,6 +67,147 @@ void main() {
     });
   });
 
+  group('computeDayStreak', () {
+    DateTime d(int y, int m, int day) => DateTime(y, m, day);
+
+    test('returns zero current and best when no qualifying days', () {
+      final s = computeDayStreak(
+        qualifyingDays: <DateTime>{},
+        referenceDay: d(2026, 4, 28),
+      );
+      expect(s.current, 0);
+      expect(s.best, 0);
+    });
+
+    test('counts current streak ending at reference day', () {
+      final s = computeDayStreak(
+        qualifyingDays: {
+          d(2026, 4, 26),
+          d(2026, 4, 27),
+          d(2026, 4, 28),
+        },
+        referenceDay: d(2026, 4, 28),
+      );
+      expect(s.current, 3);
+      expect(s.best, 3);
+    });
+
+    test('treats reference day not yet logged as still streaking', () {
+      final s = computeDayStreak(
+        qualifyingDays: {
+          d(2026, 4, 26),
+          d(2026, 4, 27),
+        },
+        referenceDay: d(2026, 4, 28),
+      );
+      expect(s.current, 2);
+      expect(s.best, 2);
+    });
+
+    test('best streak ignores gaps and exceeds current', () {
+      final s = computeDayStreak(
+        qualifyingDays: {
+          d(2026, 4, 1),
+          d(2026, 4, 2),
+          d(2026, 4, 3),
+          d(2026, 4, 4),
+          d(2026, 4, 5),
+          d(2026, 4, 27),
+          d(2026, 4, 28),
+        },
+        referenceDay: d(2026, 4, 28),
+      );
+      expect(s.current, 2);
+      expect(s.best, 5);
+    });
+
+    test('normalizes timestamps to calendar day', () {
+      final s = computeDayStreak(
+        qualifyingDays: {
+          DateTime(2026, 4, 27, 8, 30),
+          DateTime(2026, 4, 27, 19, 5),
+          DateTime(2026, 4, 28, 7, 0),
+        },
+        referenceDay: DateTime(2026, 4, 28, 23, 59),
+      );
+      expect(s.current, 2);
+    });
+
+    test('breaks streak when a day is missing before reference', () {
+      final s = computeDayStreak(
+        qualifyingDays: {
+          d(2026, 4, 24),
+          d(2026, 4, 25),
+          d(2026, 4, 27),
+        },
+        referenceDay: d(2026, 4, 28),
+      );
+      expect(s.current, 1);
+      expect(s.best, 2);
+    });
+  });
+
+  group('computeWeightTrendStats', () {
+    ({DateTime recordedAt, double weightKg}) e(DateTime t, double kg) =>
+        (recordedAt: t, weightKg: kg);
+
+    test('filters to window and sorts chronologically', () {
+      final ref = DateTime(2026, 4, 28);
+      final stats = computeWeightTrendStats(
+        entries: [
+          e(DateTime(2026, 4, 28, 8), 80.0),
+          e(DateTime(2026, 4, 1), 90.0),
+          e(DateTime(2026, 4, 22), 81.0),
+        ],
+        windowDays: 7,
+        referenceDay: ref,
+      );
+      expect(stats.points.length, 2);
+      expect(stats.points.first.weightKg, 81.0);
+      expect(stats.points.last.weightKg, 80.0);
+    });
+
+    test('reports kg/week from linear fit', () {
+      final ref = DateTime(2026, 4, 28);
+      final stats = computeWeightTrendStats(
+        entries: [
+          e(DateTime(2026, 4, 21), 80.0),
+          e(DateTime(2026, 4, 28), 79.0),
+        ],
+        windowDays: 14,
+        referenceDay: ref,
+      );
+      expect(stats.kgPerWeek, isNotNull);
+      expect(stats.kgPerWeek!, closeTo(-1.0, 0.01));
+    });
+
+    test('consistency reflects distinct days / window', () {
+      final ref = DateTime(2026, 4, 28);
+      final stats = computeWeightTrendStats(
+        entries: [
+          e(DateTime(2026, 4, 28, 6), 80.0),
+          e(DateTime(2026, 4, 28, 18), 80.2),
+          e(DateTime(2026, 4, 27, 7), 80.4),
+        ],
+        windowDays: 7,
+        referenceDay: ref,
+      );
+      expect(stats.distinctDaysLogged, 2);
+      expect(stats.consistency, closeTo(2 / 7, 0.001));
+    });
+
+    test('returns null kgPerWeek when fewer than two points', () {
+      final ref = DateTime(2026, 4, 28);
+      final stats = computeWeightTrendStats(
+        entries: [e(DateTime(2026, 4, 28), 80.0)],
+        windowDays: 7,
+        referenceDay: ref,
+      );
+      expect(stats.kgPerWeek, isNull);
+      expect(stats.hasEnoughData, isFalse);
+    });
+  });
+
   group('adjustCaloriesForProgress', () {
     test('no change when within band', () {
       expect(


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core logging flows (food/weight) and adds new repository query/update/delete paths, which could affect data integrity and date-boundary behavior despite good test coverage.
> 
> **Overview**
> Adds **multi-day navigation** to the dashboard so users can view and add food logs for past days, including routing support for `day=YYYY-MM-DD` and defaulting new entries to a deterministic timestamp on that day.
> 
> Introduces **streaks and trend analytics**: weight trend windows (7/14/30 days) with rate/consistency stats, a weigh-in streak indicator, and a food-logging adherence streak based on meeting a % of the daily calorie target.
> 
> Extends the repository with weight entry lookup/update/delete helpers and daily calorie aggregation (`dailyKcalTotals` + watch variant), and adds tests covering day-bounded queries, aggregations, streaks, and trend computations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b964909682bd374a4802de45237a5e84ddd79f35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->