### PR TITLE
Update Android release workflow to change branch naming convention fo…

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -90,7 +90,7 @@ jobs:
             Automated `pubspec.yaml` version bump.
 
             **Merge this pull request** to create the release tag and publish the Android APK on GitHub Releases.
-          branch: chore/release-${{ steps.bump.outputs.version_name }}
+          branch: release/v${{ steps.bump.outputs.version_name }}
           delete-branch: true
 
   publish_release:


### PR DESCRIPTION
…r version bumps from `chore/release` to `release/v`. This improves clarity in versioning and aligns with standard practices for release tagging.